### PR TITLE
feat(ci): add Playwright E2E testing workflow

### DIFF
--- a/.github/actions/test-playwright/action.yml
+++ b/.github/actions/test-playwright/action.yml
@@ -1,0 +1,48 @@
+name: Test Playwright E2E (Web)
+description: Run Playwright web E2E tests against the Angular dev server. All API calls are mocked via page.route — no real backend required.
+inputs:
+  context-path:
+    description: 'Path to the Angular/Ionic project containing package.json and playwright.config.ts'
+    required: true
+  node-version:
+    description: 'Node.js version to use'
+    required: false
+    default: '20'
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: 'npm'
+        cache-dependency-path: ${{ inputs.context-path }}/package-lock.json
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        cd ${{ inputs.context-path }}
+        npm ci
+
+    - name: Install Playwright Chromium and OS dependencies
+      shell: bash
+      run: |
+        cd ${{ inputs.context-path }}
+        npx playwright install --with-deps chromium
+
+    - name: Run E2E tests
+      shell: bash
+      env:
+        CI: "true"
+        START_SERVER_AND_TEST_HTTP_TIMEOUT: "120000"
+      run: |
+        cd ${{ inputs.context-path }}
+        npm run e2e:web:with-app
+
+    - name: Upload Playwright report on failure
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-report-${{ github.run_id }}
+        path: ${{ inputs.context-path }}/playwright-report/
+        retention-days: 7

--- a/.github/workflows/deploy_apps.yml
+++ b/.github/workflows/deploy_apps.yml
@@ -90,6 +90,48 @@ jobs:
           terraform_environment: ${{ inputs.environment }}
           terraform_stack: cognito
 
+  test_web_app:
+    name: Test travelhub (unit)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Angular tests
+        uses: ./.github/actions/test-angular
+        with:
+          context-path: user_interface
+
+  test_e2e:
+    name: E2E travelhub (Playwright)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Playwright E2E tests
+        uses: ./.github/actions/test-playwright
+        with:
+          context-path: user_interface
+
+  build_web_image:
+    name: Build and Push travelhub
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    needs: [test_web_app, test_e2e, deploy_container_registry_stack]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build and Push Docker Image to ECR
+        uses: ./.github/actions/build_image
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          ecr-repo: web_travelhub
+          image-tag: latest
+          context-path: user_interface
+
   build_and_push:
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
@@ -133,10 +175,6 @@ jobs:
             language: dotnet
             ecr-repo: api_pricing_orchestator
             context-path: services/PricingOrchestator
-          - name: travelhub
-            language: node
-            ecr-repo: web_travelhub
-            context-path: user_interface
     name: Build and Push ${{ matrix.name }}
     steps:
       - name: Checkout repository
@@ -252,7 +290,7 @@ jobs:
   deploy_web_app_stack:
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
-    needs: [build_and_push, deploy_api_gateway_stack]
+    needs: [build_and_push, build_web_image, deploy_api_gateway_stack]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/deploy_stack.yml
+++ b/.github/workflows/deploy_stack.yml
@@ -101,6 +101,21 @@ jobs:
         with:
           context-path: user_interface
 
+  # Runs Playwright E2E tests against the Angular dev server (all API calls mocked via page.route).
+  # Runs only when deploying web_app.
+  test_e2e:
+    name: E2E travelhub (Playwright)
+    if: ${{ inputs.stack == 'web_app' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Playwright E2E tests
+        uses: ./.github/actions/test-playwright
+        with:
+          context-path: user_interface
+
   # Builds and pushes the web app (SPA) image.
   # Runs only when deploying web_app and after tests pass.
   build_web_image:
@@ -108,7 +123,7 @@ jobs:
     if: ${{ inputs.stack == 'web_app' }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
-    needs: [test_web_app]
+    needs: [test_web_app, test_e2e]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -236,7 +251,7 @@ jobs:
     name: Deploy ${{ inputs.stack }} → ${{ inputs.environment }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
-    needs: [build_backend_images, test_web_app, build_web_image, redeploy_web_container]
+    needs: [build_backend_images, test_web_app, test_e2e, build_web_image, redeploy_web_container]
     if: ${{ always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -54,6 +54,18 @@ jobs:
         with:
           context-path: user_interface
 
+  test_e2e:
+    name: E2E travelhub (Playwright)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Playwright E2E tests
+        uses: ./.github/actions/test-playwright
+        with:
+          context-path: user_interface
+
   build_and_push:
     runs-on: ubuntu-latest
     environment: develop
@@ -112,7 +124,7 @@ jobs:
   build_web_image:
     name: Build travelhub
     runs-on: ubuntu-latest
-    needs: [ test_frontend ]
+    needs: [ test_frontend, test_e2e ]
     environment: develop
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This pull request introduces Playwright-based E2E testing for the web application and integrates these tests into the CI/CD workflows. It adds a reusable composite GitHub Action for running Playwright E2E tests, ensures E2E tests are run before building and deploying the web app, and updates job dependencies to enforce this order. The changes improve test coverage and deployment reliability by ensuring E2E tests pass before images are built or deployed.

**E2E Testing Integration:**

* Added a new composite GitHub Action (`.github/actions/test-playwright/action.yml`) to run Playwright E2E tests with mocked API calls, supporting configurable Node.js versions and project paths.
* Updated `pr_validation.yml`, `deploy_apps.yml`, and `deploy_stack.yml` workflows to add `test_e2e` jobs that run Playwright E2E tests on the web app, and made building the web image depend on both unit and E2E tests passing. [[1]](diffhunk://#diff-0d7d788f6715cff2f771c41f16e53a80e350c4fe8c7211f2981183305480653aR57-R68) [[2]](diffhunk://#diff-0d7d788f6715cff2f771c41f16e53a80e350c4fe8c7211f2981183305480653aL115-R127) [[3]](diffhunk://#diff-303feca349812ea9a458eae99dc55c362c12a8c7c7a6fdcb1442f5a078405f14R93-R134) [[4]](diffhunk://#diff-0230c618cf840c7155777c603c576d509451155e5884889fb2c62c34baebfb67R104-R126)
* Modified deployment job dependencies so that deployment only proceeds if E2E tests are successful, increasing deployment safety. [[1]](diffhunk://#diff-0230c618cf840c7155777c603c576d509451155e5884889fb2c62c34baebfb67L239-R254) [[2]](diffhunk://#diff-303feca349812ea9a458eae99dc55c362c12a8c7c7a6fdcb1442f5a078405f14L255-R293)

**Workflow Simplification:**

* Removed the web app build from the generic `build_and_push` matrix in `deploy_apps.yml`, moving it to a dedicated job that depends on passing tests, for clearer workflow structure.