### PR TITLE
feat(ci): add GitHub Actions for building Android APK

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -1,0 +1,82 @@
+name: Build Android APK
+description: Builds a debug Android APK from the Angular/Ionic/Capacitor app. Syncs the web build into the native project then assembles with Gradle.
+inputs:
+  context-path:
+    description: 'Path to the Angular/Ionic project containing package.json and the android/ directory'
+    required: true
+  node-version:
+    description: 'Node.js version to use'
+    required: false
+    default: '20'
+  java-version:
+    description: 'JDK version to use (must be ≤23 — required by Gradle 8.11.1 and AGP 8.7.2)'
+    required: false
+    default: '21'
+  api-base-url:
+    description: 'API Gateway base URL baked into assets/config.json at build time (optional — falls back to the value already in config.json)'
+    required: false
+    default: ''
+  property-api-path:
+    description: 'Property API path baked into assets/config.json (optional)'
+    required: false
+    default: ''
+  property-api-token:
+    description: 'Property API token baked into assets/config.json (optional)'
+    required: false
+    default: ''
+outputs:
+  apk-path:
+    description: 'Relative path to the built APK file'
+    value: ${{ steps.locate-apk.outputs.apk-path }}
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: 'npm'
+        cache-dependency-path: ${{ inputs.context-path }}/package-lock.json
+
+    - name: Install Node dependencies
+      shell: bash
+      run: |
+        cd ${{ inputs.context-path }}
+        npm ci
+
+    - name: Set up JDK ${{ inputs.java-version }}
+      uses: actions/setup-java@v4
+      with:
+        java-version: ${{ inputs.java-version }}
+        distribution: temurin
+        cache: gradle
+
+    - name: Build web app and sync into Android project
+      shell: bash
+      env:
+        API_BASE_URL: ${{ inputs.api-base-url }}
+        PROPERTY_API_PATH: ${{ inputs.property-api-path }}
+        PROPERTY_API_TOKEN: ${{ inputs.property-api-token }}
+      run: |
+        cd ${{ inputs.context-path }}
+        npm run android:sync
+
+    - name: Build debug APK
+      shell: bash
+      run: |
+        cd ${{ inputs.context-path }}/android
+        ./gradlew assembleDebug --no-daemon
+
+    - name: Locate APK
+      id: locate-apk
+      shell: bash
+      run: |
+        APK_PATH="${{ inputs.context-path }}/android/app/build/outputs/apk/debug/app-debug.apk"
+        echo "apk-path=$APK_PATH" >> $GITHUB_OUTPUT
+
+    - name: Upload APK artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: travelhub-android-debug-${{ github.run_id }}
+        path: ${{ inputs.context-path }}/android/app/build/outputs/apk/debug/app-debug.apk
+        retention-days: 30

--- a/.github/workflows/build_android_apk.yml
+++ b/.github/workflows/build_android_apk.yml
@@ -1,0 +1,33 @@
+name: Build Android APK
+
+on:
+  workflow_dispatch:
+    inputs:
+      api_base_url:
+        description: 'API Gateway base URL to embed in the app (leave blank to use the default already in config.json)'
+        required: false
+        default: ''
+      property_api_path:
+        description: 'Property API path (leave blank for default: /poc-properties/api/property)'
+        required: false
+        default: ''
+      property_api_token:
+        description: 'Property API token (leave blank for default: empty)'
+        required: false
+        default: ''
+
+jobs:
+  build_apk:
+    name: Build travelhub debug APK
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build Android APK
+        uses: ./.github/actions/build-android
+        with:
+          context-path: user_interface
+          api-base-url: ${{ inputs.api_base_url }}
+          property-api-path: ${{ inputs.property_api_path }}
+          property-api-token: ${{ inputs.property_api_token }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow and a reusable composite action to automate building a debug Android APK for the project. The workflow allows for manual triggering with customizable API configuration, and the composite action encapsulates all the steps required to build and upload the APK artifact.

**New GitHub Actions workflow and composite action for building Android APKs:**

_Workflow automation:_
* Added `.github/workflows/build_android_apk.yml` to provide a manually-triggered workflow for building the Android APK, with optional inputs for API configuration.

_Composite action for build process:_
* Introduced `.github/actions/build-android/action.yml`, a composite action that handles Node.js/JDK setup, dependency installation, web build synchronization, APK assembly, and artifact upload.
* The composite action accepts parameters for context path, Node and Java versions, and API configuration, and outputs the path to the built APK.

_Artifact handling:_
* The workflow and action ensure the built APK is uploaded as a workflow artifact, making it available for download and further testing. [[1]](diffhunk://#diff-0d295954e87f3b56b3e79e72c76a9352f900b2b6558eb6d881d54d0601d27129R1-R82) [[2]](diffhunk://#diff-c5ede70e023177dafe85757a80c11a5a085d3eb2e24fa16accebc0220565c4d4R1-R33)