### PR TITLE
Build APK Workflow - Update Node.js version and Gradle setup in CI configuration

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -7,11 +7,15 @@ inputs:
   node-version:
     description: 'Node.js version to use'
     required: false
-    default: '22'
+    default: '20'
   java-version:
-    description: 'JDK version to use (must be ≤23 — required by Gradle 8.11.1 and AGP 8.7.2)'
+    description: 'JDK version to use (must be ≤23 — required by AGP 8.7.2)'
     required: false
     default: '21'
+  gradle-version:
+    description: 'Gradle version to install via gradle/actions/setup-gradle (bypasses the wrapper JAR entirely)'
+    required: false
+    default: '8.11.1'
   api-base-url:
     description: 'API Gateway base URL baked into assets/config.json at build time (optional — falls back to the value already in config.json)'
     required: false
@@ -49,19 +53,6 @@ runs:
       with:
         java-version: ${{ inputs.java-version }}
         distribution: temurin
-        cache: gradle
-
-    - name: Restore Gradle wrapper JAR
-      shell: bash
-      run: |
-        JAR="${{ inputs.context-path }}/android/gradle/wrapper/gradle-wrapper.jar"
-        if [ ! -f "$JAR" ]; then
-          GRADLE_VER=$(grep -oP 'gradle-\K[0-9]+\.[0-9]+(\.[0-9]+)?(?=-)' \
-            "${{ inputs.context-path }}/android/gradle/wrapper/gradle-wrapper.properties")
-          echo "gradle-wrapper.jar missing — regenerating for Gradle ${GRADLE_VER}"
-          gradle wrapper --gradle-version="$GRADLE_VER" --distribution-type=all \
-            --project-dir="${{ inputs.context-path }}/android"
-        fi
 
     - name: Build web app and sync into Android project
       shell: bash
@@ -73,11 +64,16 @@ runs:
         cd ${{ inputs.context-path }}
         npm run android:sync
 
+    - name: Set up Gradle ${{ inputs.gradle-version }}
+      uses: gradle/actions/setup-gradle@v4
+      with:
+        gradle-version: ${{ inputs.gradle-version }}
+
     - name: Build debug APK
       shell: bash
       run: |
         cd ${{ inputs.context-path }}/android
-        ./gradlew assembleDebug --no-daemon
+        gradle assembleDebug --no-daemon
 
     - name: Locate APK
       id: locate-apk

--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -51,6 +51,18 @@ runs:
         distribution: temurin
         cache: gradle
 
+    - name: Restore Gradle wrapper JAR
+      shell: bash
+      run: |
+        JAR="${{ inputs.context-path }}/android/gradle/wrapper/gradle-wrapper.jar"
+        if [ ! -f "$JAR" ]; then
+          GRADLE_VER=$(grep -oP 'gradle-\K[0-9]+\.[0-9]+(\.[0-9]+)?(?=-)' \
+            "${{ inputs.context-path }}/android/gradle/wrapper/gradle-wrapper.properties")
+          echo "gradle-wrapper.jar missing — regenerating for Gradle ${GRADLE_VER}"
+          gradle wrapper --gradle-version="$GRADLE_VER" --distribution-type=all \
+            --project-dir="${{ inputs.context-path }}/android"
+        fi
+
     - name: Build web app and sync into Android project
       shell: bash
       env:

--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -5,9 +5,9 @@ inputs:
     description: 'Path to the Angular/Ionic project containing package.json and the android/ directory'
     required: true
   node-version:
-    description: 'Node.js version to use'
+    description: 'Node.js version to use (must be >=22 — required by @capacitor/cli@8.3.0)'
     required: false
-    default: '20'
+    default: '22'
   java-version:
     description: 'JDK version to use (must be ≤23 — required by AGP 8.7.2)'
     required: false

--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -7,7 +7,7 @@ inputs:
   node-version:
     description: 'Node.js version to use'
     required: false
-    default: '20'
+    default: '22'
   java-version:
     description: 'JDK version to use (must be ≤23 — required by Gradle 8.11.1 and AGP 8.7.2)'
     required: false


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building Android apps, focusing on improved compatibility and build reliability. The main changes involve updating the default Node.js version, clarifying Java version requirements, adding support for specifying the Gradle version, and switching to using the Gradle CLI directly instead of the wrapper.

**Build environment updates:**

* Updated the default `node-version` to 22 (from 20) and clarified that Node.js 22+ is required for `@capacitor/cli@8.3.0`.
* Clarified the `java-version` description to indicate it must be ≤23 due to AGP 8.7.2 requirements.

**Gradle setup and usage:**

* Added a new `gradle-version` input, allowing explicit selection of the Gradle version to install via `gradle/actions/setup-gradle`, bypassing the wrapper JAR.
* Added a step to set up Gradle using the specified version and `gradle/actions/setup-gradle@v4`.
* Changed the APK build step to use the installed Gradle CLI (`gradle assembleDebug`) instead of the wrapper (`./gradlew`).

**Other workflow adjustments:**

* Removed the `cache: gradle` option from the Java setup step.