### PR TITLE
Creación de página pricing configuration y reports

### DIFF
--- a/.github/instructions/frontend-guardrails.instructions.md
+++ b/.github/instructions/frontend-guardrails.instructions.md
@@ -1,5 +1,5 @@
 ---
-description: "Always-on frontend guardrails for user_interface changes: Ionic-first UI, shared-component reuse, theme/global-style token reuse, UI unit-test discipline, and portal-hoteles/main-project reuse boundaries."
+description: "Always-on frontend guardrails for user_interface changes: Ionic-first UI, shared-component reuse, theme/global-style token reuse, accessibility compliance with a11y-audit, UI unit-test discipline, and portal-hoteles/main-project reuse boundaries."
 applyTo: "user_interface/{src,projects/portal-hoteles/src}/**/*.{ts,html,scss}"
 ---
 
@@ -54,6 +54,11 @@ Mandatory rules
 - When new core elements are needed, create them only under user_interface/src/app/core.
 - When new shared components are needed, create them only under user_interface/src/app/shared/components.
 
+7. Accessibility compliance for new UI changes (mandatory)
+- Any new or modified UI behavior must comply with accessibility requirements (semantic structure, keyboard access, visible focus states, accessible labels/names, and sufficient contrast).
+- Assess accessibility using the a11y-audit skill before finalizing frontend changes.
+- If any accessibility issue remains, explicitly report it with impact, rationale, and a remediation plan.
+
 Allowed exceptions
 - clamp(...)
 - calc(...)
@@ -69,6 +74,7 @@ Required pre-edit checklist
 3. List theme tokens/global patterns to reuse.
 4. List any exception needed and rationale.
 5. For portal-hoteles work, confirm that no new local core/shared files are introduced under projects/portal-hoteles/src/app.
+6. List accessibility checks considered and confirm that a11y-audit was used (or explain why it was not possible).
 
 Required response addendum for frontend changes
 1. Compliance summary
@@ -90,3 +96,7 @@ Required response addendum for frontend changes
 - Any exception with rationale
 6. Portal-hoteles boundary compliance
 - Confirm the feature stays page-only in portal-hoteles and reuses main-project core/shared assets.
+7. Accessibility compliance
+- Accessibility checks applied for the change
+- a11y-audit assessment result
+- Any remaining a11y risk and remediation plan

--- a/user_interface/e2e/wiremock/mappings/pricingengine-propertyprice.json
+++ b/user_interface/e2e/wiremock/mappings/pricingengine-propertyprice.json
@@ -1,7 +1,21 @@
 {
   "request": {
     "method": "GET",
-    "urlPathPattern": "^/(pricing-engine/)?api/PropertyPrice$"
+    "urlPathPattern": "^/(pricing-engine/)?api/PropertyPrice$",
+    "queryParameters": {
+      "propertyId": {
+        "matches": "^[0-9a-fA-F-]{36}$"
+      },
+      "guests": {
+        "matches": "^[0-9]+$"
+      },
+      "dateInit": {
+        "matches": "^\\d{4}-\\d{2}-\\d{2}$"
+      },
+      "dateFinish": {
+        "matches": "^\\d{4}-\\d{2}-\\d{2}$"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/user_interface/e2e/wiremock/mappings/pricingorchestator-property.json
+++ b/user_interface/e2e/wiremock/mappings/pricingorchestator-property.json
@@ -1,7 +1,21 @@
 {
   "request": {
     "method": "GET",
-    "urlPathPattern": "^/(pricing-orchestator/)?api/Property$"
+    "urlPathPattern": "^/(pricing-orchestator/)?api/Property$",
+    "queryParameters": {
+      "propertyId": {
+        "matches": "^[0-9a-fA-F-]{36}$"
+      },
+      "guests": {
+        "matches": "^[0-9]+$"
+      },
+      "dateInit": {
+        "matches": "^\\d{4}-\\d{2}-\\d{2}$"
+      },
+      "dateFinish": {
+        "matches": "^\\d{4}-\\d{2}-\\d{2}$"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/user_interface/e2e/wiremock/podman-compose.yml
+++ b/user_interface/e2e/wiremock/podman-compose.yml
@@ -4,7 +4,7 @@ services:
   wiremock:
     image: docker.io/wiremock/wiremock:3.9.1
     ports:
-      - "8080:8080"
+      - "8081:8080"
     volumes:
       - ./mappings:/home/wiremock/mappings:ro
       - ./__files:/home/wiremock/__files:ro

--- a/user_interface/projects/portal-hoteles/src/app/app-routing.module.ts
+++ b/user_interface/projects/portal-hoteles/src/app/app-routing.module.ts
@@ -24,6 +24,20 @@ const routes: Routes = [
       ),
   },
   {
+    path: 'pricing',
+    canActivate: [portalHotelesAuthGuard],
+    loadComponent: () =>
+      import('./pages/pricing-configuration/pricing-configuration.page').then(
+        (m) => m.PortalHotelesPricingConfigurationPage,
+      ),
+  },
+  {
+    path: 'reports',
+    canActivate: [portalHotelesAuthGuard],
+    loadComponent: () =>
+      import('./pages/reports/reports.page').then((m) => m.PortalHotelesReportsPage),
+  },
+  {
     path: 'home',
     redirectTo: 'dashboard',
     pathMatch: 'full',

--- a/user_interface/projects/portal-hoteles/src/app/pages/pricing-configuration/pricing-configuration.page.html
+++ b/user_interface/projects/portal-hoteles/src/app/pages/pricing-configuration/pricing-configuration.page.html
@@ -1,0 +1,190 @@
+<ion-content class="portal-hoteles-pricing-content">
+  <!-- <section class="portal-hoteles-pricing-hero">
+    <p class="portal-hoteles-pricing-hero__kicker">Pricing Management</p>
+    <h1>Create, edit, and manage room rates and discounts</h1>
+  </section> -->
+
+  <section class="portal-hoteles-pricing-grid portal-hoteles-pricing-grid--full-width">
+    <portal-hoteles-grid-card
+      cardClass="portal-hoteles-grid-card--panel portal-hoteles-grid-card--wide"
+      title="Pricing Management"
+      subtitle="Create, edit, and manage room rates and discounts"
+    >
+      <div slot="header-actions" class="portal-hoteles-pricing-toolbar-header" role="group" aria-label="Room rate filters and actions">
+        <div class="portal-hoteles-pricing-toolbar-header__filters">
+          <ion-select
+            class="portal-hoteles-pricing-toolbar-header__select"
+            interface="popover"
+            aria-label="Filter by room type"
+          >
+            <ion-select-option>All Room Types</ion-select-option>
+            <ion-select-option>Superior Double</ion-select-option>
+            <ion-select-option>Deluxe Suite</ion-select-option>
+            <ion-select-option>Standard Room</ion-select-option>
+            <ion-select-option>Junior Suite</ion-select-option>
+          </ion-select>
+
+          <ion-select
+            class="portal-hoteles-pricing-toolbar-header__select"
+            interface="popover"
+            aria-label="Select currency"
+          >
+            <ion-select-option>USD</ion-select-option>
+            <ion-select-option>EUR</ion-select-option>
+            <ion-select-option>COP</ion-select-option>
+          </ion-select>
+
+          <ion-select
+            class="portal-hoteles-pricing-toolbar-header__select"
+            interface="popover"
+            aria-label="Filter by season"
+          >
+            <ion-select-option>All Seasons</ion-select-option>
+            <ion-select-option>High Season</ion-select-option>
+            <ion-select-option>Low Season</ion-select-option>
+          </ion-select>
+        </div>
+
+        <ion-button
+          size="small"
+          fill="solid"
+          class="portal-hoteles-pricing-toolbar-header__action-button"
+        >
+          + New Rate
+        </ion-button>
+      </div>
+
+      <div class="portal-hoteles-pricing-content-toolbar">
+        <ion-input class="portal-hoteles-pricing-content-toolbar__search" placeholder="Search by room type..."></ion-input>
+      </div>
+
+      <p class="portal-hoteles-pricing-table__message" *ngIf="isLoading">
+        Loading pricing data...
+      </p>
+
+      <div class="portal-hoteles-pricing-table" *ngIf="roomRateRows.length > 0">
+        <div class="portal-hoteles-pricing-table__header" role="row">
+          <span>Room Type</span>
+          <span>Capacity</span>
+          <span>Base Rate</span>
+          <span>Discount</span>
+          <span>Final Rate</span>
+          <span>Status</span>
+          <span>Actions</span>
+        </div>
+
+        <article class="portal-hoteles-pricing-table__row" *ngFor="let row of roomRateRows; trackBy: trackByRoomType">
+          <div class="portal-hoteles-pricing-table__room-type">
+            <strong>{{ row.roomType }}</strong>
+            <span class="portal-hoteles-pricing-table__meta">{{ row.roomTypeId }}</span>
+          </div>
+
+          <span>{{ row.capacityLabel }}</span>
+          <strong>{{ row.baseRateLabel }}</strong>
+          <span [class]="row.discountClass">{{ row.discountLabel }}</span>
+          <strong class="portal-hoteles-pricing-table__accent">{{ row.finalRateLabel }}</strong>
+          <span [class]="row.statusClass">{{ row.status }}</span>
+          <ion-button fill="clear" size="small" class="portal-hoteles-pricing-table__actions-button">⋮</ion-button>
+        </article>
+
+        <footer class="portal-hoteles-pricing-table__footer">
+          <span>Showing 1-{{ roomRateRows.length }} of 12 room types</span>
+          <div class="portal-hoteles-pricing-table__pagination">
+            <ion-button fill="outline" size="small" class="portal-hoteles-pricing-table__pagination-button">‹</ion-button>
+            <span class="portal-hoteles-pricing-table__page portal-hoteles-pricing-table__page--active">1</span>
+            <span class="portal-hoteles-pricing-table__page">2</span>
+            <ion-button fill="outline" size="small" class="portal-hoteles-pricing-table__pagination-button">›</ion-button>
+          </div>
+        </footer>
+      </div>
+
+      <p class="portal-hoteles-pricing-table__message" *ngIf="!isLoading && !errorMessage && roomRateRows.length === 0">
+        No room rates available.
+      </p>
+      <p class="portal-hoteles-pricing-table__message" *ngIf="!isLoading && errorMessage">
+        {{ errorMessage }}
+      </p>
+      <p class="portal-hoteles-pricing-table__message" *ngIf="!isLoading && !errorMessage && roomRateRows.length === 0">
+        No pricing data available for this property.
+      </p>
+    </portal-hoteles-grid-card>
+
+    <portal-hoteles-grid-card
+      cardClass="portal-hoteles-grid-card--panel portal-hoteles-grid-card--wide"
+      title="Seasonal Pricing Rules"
+      subtitle="Manage seasonal pricing modifiers"
+    >
+      <div slot="header-actions" class="portal-hoteles-pricing-toolbar-header" role="group" aria-label="Seasonal pricing filters and actions">
+        <div class="portal-hoteles-pricing-toolbar-header__filters">
+          <ion-select
+            class="portal-hoteles-pricing-toolbar-header__select"
+            interface="popover"
+            aria-label="Filter by room type"
+          >
+            <ion-select-option>All Room Types</ion-select-option>
+            <ion-select-option>Superior Double</ion-select-option>
+            <ion-select-option>Deluxe Suite</ion-select-option>
+            <ion-select-option>Standard Room</ion-select-option>
+            <ion-select-option>Junior Suite</ion-select-option>
+          </ion-select>
+
+          <ion-select
+            class="portal-hoteles-pricing-toolbar-header__select"
+            interface="popover"
+            aria-label="Select currency"
+          >
+            <ion-select-option>USD</ion-select-option>
+            <ion-select-option>EUR</ion-select-option>
+            <ion-select-option>COP</ion-select-option>
+          </ion-select>
+
+          <ion-select
+            class="portal-hoteles-pricing-toolbar-header__select"
+            interface="popover"
+            aria-label="Filter by season"
+          >
+            <ion-select-option>All Seasons</ion-select-option>
+            <ion-select-option>High Season</ion-select-option>
+            <ion-select-option>Low Season</ion-select-option>
+          </ion-select>
+        </div>
+
+        <ion-button
+          size="small"
+          fill="solid"
+          class="portal-hoteles-pricing-toolbar-header__action-button"
+        >
+          + New Rate
+        </ion-button>
+      </div>
+
+      <div class="portal-hoteles-pricing-table" *ngIf="seasonalRulesRows.length > 0">
+        <div class="portal-hoteles-pricing-table__header portal-hoteles-pricing-table__header--seasonal" role="row">
+          <span>Season</span>
+          <span>Date Range</span>
+          <span>Modifier</span>
+          <span>Status</span>
+          <span>Actions</span>
+        </div>
+
+        <article class="portal-hoteles-pricing-table__row portal-hoteles-pricing-table__row--seasonal" *ngFor="let row of seasonalRulesRows; trackBy: trackBySeason">
+          <div>
+            <strong>{{ row.season }}</strong>
+            <span class="portal-hoteles-pricing-table__meta">{{ row.description }}</span>
+          </div>
+          <div>
+            <span>{{ row.dateRange }}</span>
+            <span class="portal-hoteles-pricing-table__meta">{{ row.helperDateRange }}</span>
+          </div>
+          <span [class]="row.modifierClass">{{ row.modifierLabel }}</span>
+          <span [class]="row.statusClass">{{ row.status }}</span>
+          <ion-button fill="clear" size="small" class="portal-hoteles-pricing-table__actions-button">⋮</ion-button>
+        </article>
+      </div>
+
+      <p class="portal-hoteles-pricing-table__message" *ngIf="seasonalRulesRows.length === 0">
+        No seasonal rules available.
+      </p>
+    </portal-hoteles-grid-card>
+  </section>
+</ion-content>

--- a/user_interface/projects/portal-hoteles/src/app/pages/pricing-configuration/pricing-configuration.page.scss
+++ b/user_interface/projects/portal-hoteles/src/app/pages/pricing-configuration/pricing-configuration.page.scss
@@ -1,0 +1,443 @@
+/*
+ * Portal-Hoteles Pricing Configuration Page Styles
+ * ----------------------------------------------------------------------------
+ * Reuses theme tokens from variables.scss and global patterns from global.scss
+ */
+
+/* Pricing Content Container */
+.portal-hoteles-pricing-content {
+  --background: transparent;
+  --color: var(--th-neutral-900);
+  color: var(--th-neutral-900);
+}
+
+/* Hero Section */
+.portal-hoteles-pricing-hero {
+  padding: 0 0 var(--th-space-6);
+}
+
+.portal-hoteles-pricing-hero__kicker {
+  margin: 0 0 var(--th-space-2);
+  color: var(--th-primary-700);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: var(--th-text-caption-size);
+  font-weight: var(--th-font-weight-semibold);
+}
+
+.portal-hoteles-pricing-hero h1 {
+  margin: 0;
+  color: var(--th-neutral-900);
+  font-size: var(--th-text-h1-size);
+  line-height: 1.1;
+}
+
+/* Grid Layout */
+.portal-hoteles-pricing-grid {
+  display: grid;
+  gap: var(--th-space-4);
+}
+
+.portal-hoteles-pricing-grid--full-width {
+  grid-template-columns: minmax(0, 0.8fr);
+  justify-content: center;
+}
+
+/* Panel Cards */
+.portal-hoteles-pricing-grid--panel {
+  grid-column: 1 / -1;
+}
+
+.portal-hoteles-pricing-grid--sidebar {
+  grid-column: 1 / -1;
+}
+
+.portal-hoteles-pricing-toolbar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--th-space-3);
+  border: 1px solid var(--th-neutral-300);
+  border-radius: var(--th-radius-md);
+  background: var(--th-white);
+  padding: var(--th-space-2);
+}
+
+.portal-hoteles-pricing-toolbar-header__filters {
+  display: flex;
+  align-items: center;
+  gap: var(--th-space-2);
+}
+
+.portal-hoteles-pricing-toolbar-header__select {
+  --background: var(--th-white);
+  --border-color: var(--th-neutral-300);
+  --border-style: solid;
+  --border-width: 1px;
+  --border-radius: var(--th-radius-md);
+  --padding-start: 10px;
+  min-width: 140px;
+}
+
+.portal-hoteles-pricing-toolbar-header__action-button {
+  --background: var(--th-primary-700);
+  --background-hover: var(--th-primary-800);
+  --color: var(--th-white);
+  margin: 0;
+  text-transform: none;
+  font-size: var(--th-text-body-sm-size);
+}
+
+.portal-hoteles-pricing-content-toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--th-space-2);
+  margin-bottom: var(--th-space-3);
+}
+
+.portal-hoteles-pricing-content-toolbar__search {
+  --background: var(--th-white);
+  --border-color: var(--th-neutral-300);
+  --border-width: 1px;
+  --border-style: solid;
+  --border-radius: var(--th-radius-md);
+  --padding-start: 10px;
+  flex: 1;
+}
+
+/* Table Styles */
+.portal-hoteles-pricing-table {
+  display: flex;
+  flex-direction: column;
+  gap: var(--th-space-3);
+  margin-top: var(--th-space-2);
+}
+
+.portal-hoteles-pricing-table__header,
+.portal-hoteles-pricing-table__row {
+  padding: 18px 12px;
+  display: grid;
+  grid-template-columns: minmax(180px, 1.5fr) minmax(100px, 0.8fr) repeat(3, minmax(110px, 1fr)) minmax(72px, 0.5fr) 46px;
+  align-items: center;
+  gap: var(--th-space-3);
+  border: 1px solid var(--th-neutral-300);
+  border-radius: var(--th-radius-lg);
+  background: var(--th-white);
+}
+
+.portal-hoteles-pricing-table__header{
+  font-weight: var(--th-font-weight-medium);
+}
+
+
+/* Room Type Column */
+.portal-hoteles-pricing-table__room-type {
+  display: flex;
+  flex-direction: column;
+}
+
+.portal-hoteles-pricing-table__meta {
+  display: block;
+  margin-top: 2px;
+  color: var(--th-neutral-600);
+  font-size: var(--th-text-caption-size);
+}
+
+.portal-hoteles-pricing-table__accent {
+  color: var(--th-primary-700);
+}
+
+.portal-hoteles-pricing-table__room-type-id {
+  font-size: var(--th-text-caption-size);
+  color: var(--th-neutral-600);
+}
+
+/* Capacity Column */
+.portal-hoteles-pricing-table__capacity {
+  display: flex;
+  align-items: center;
+}
+
+.portal-hoteles-pricing-table__capacity-input {
+  width: 100%;
+}
+
+/* Base Rate Column */
+.portal-hoteles-pricing-table__base-rate {
+  display: flex;
+  align-items: center;
+}
+
+.portal-hoteles-pricing-table__base-rate-input {
+  width: 100%;
+}
+
+/* Discount Column */
+.portal-hoteles-pricing-table__discount {
+  display: flex;
+  align-items: center;
+}
+
+.portal-hoteles-pricing-table__discount-input {
+  width: 100%;
+}
+
+/* Final Rate Column */
+.portal-hoteles-pricing-table__final-rate {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Status Column */
+.portal-hoteles-pricing-table__status {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Actions Column */
+.portal-hoteles-pricing-table__actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--th-space-2);
+}
+
+.portal-hoteles-pricing-table__actions-button {
+  --color: var(--th-neutral-500);
+  margin: 0;
+}
+
+/* Date Range Column */
+.portal-hoteles-pricing-table__date-range {
+  display: flex;
+  align-items: center;
+}
+
+.portal-hoteles-pricing-table__date-range-input {
+  width: 100%;
+}
+
+/* Modifier Column */
+.portal-hoteles-pricing-table__modifier {
+  display: flex;
+  align-items: center;
+}
+
+.portal-hoteles-pricing-table__modifier-input {
+  width: 100%;
+}
+
+/* Footer */
+.portal-hoteles-pricing-table__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--th-space-3);
+  color: var(--th-neutral-600);
+  font-size: var(--th-text-body-sm-size);
+}
+
+.portal-hoteles-pricing-table__pagination {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--th-space-2);
+}
+
+.portal-hoteles-pricing-table__pagination-button {
+  --border-color: var(--th-neutral-300);
+  --color: var(--th-neutral-700);
+  --padding-start: 12px;
+  --padding-end: 12px;
+  font-size: var(--th-text-body-sm-size);
+  text-transform: none;
+}
+
+.portal-hoteles-pricing-table__pagination-label {
+  color: var(--th-neutral-600);
+}
+
+.portal-hoteles-pricing-table__page {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  border: 1px solid var(--th-neutral-300);
+  color: var(--th-neutral-700);
+  font-size: var(--th-text-caption-size);
+}
+
+.portal-hoteles-pricing-table__page--active {
+  border-color: var(--th-primary-700);
+  background: var(--th-primary-700);
+  color: var(--th-white);
+}
+
+/* Message */
+.portal-hoteles-pricing-table__message {
+  padding: var(--th-space-4);
+  color: var(--th-neutral-600);
+  font-size: var(--th-text-body-sm-size);
+  text-align: center;
+}
+
+/* Status Classes */
+.portal-hoteles-pricing-status {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: fit-content;
+  max-width: 100%;
+  border-radius: var(--th-radius-full);
+  padding: var(--th-space-1) var(--th-space-3);
+  font-size: var(--th-text-caption-size);
+  font-weight: var(--th-font-weight-medium);
+}
+
+.portal-hoteles-pricing-status--active {
+  color: var(--th-success-700);
+  background: var(--th-success-50);
+}
+
+.portal-hoteles-pricing-status--inactive {
+  color: var(--th-neutral-700);
+  background: var(--th-neutral-100);
+}
+
+.portal-hoteles-pricing-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--th-radius-full);
+  padding: 5px 8px;
+  font-size: var(--th-text-caption-size);
+  font-weight: var(--th-font-weight-semibold);
+  width: fit-content;
+}
+
+.portal-hoteles-pricing-badge--danger {
+  color: var(--th-error-700);
+  background: var(--th-error-50);
+}
+
+.portal-hoteles-pricing-badge--success {
+  color: var(--th-success-700);
+  background: var(--th-success-50);
+}
+
+.portal-hoteles-pricing-table__header--seasonal,
+.portal-hoteles-pricing-table__row--seasonal {
+  grid-template-columns: minmax(200px, 1.4fr) minmax(180px, 1.2fr) minmax(100px, 0.8fr) minmax(72px, 0.5fr) 46px;
+}
+
+/* Input Field Styles */
+ion-input {
+  --input-bg-color: var(--th-white);
+  --input-border-color: var(--th-neutral-300);
+  --input-color: var(--th-neutral-900);
+  --input-placeholder-color: var(--th-neutral-400);
+  --input-border-width: 1px;
+  --border-radius: var(--th-radius-md);
+}
+
+ion-input:focus {
+  --input-border-color: var(--th-primary-500);
+  --box-shadow: 0 0 0 3px var(--th-primary-100);
+}
+
+ion-input ion-label {
+  font-size: var(--th-text-body-sm-size);
+}
+
+/* Button Styles */
+ion-button {
+  --border-color: var(--th-neutral-300);
+  --color: var(--th-neutral-700);
+  --padding-start: 12px;
+  --padding-end: 12px;
+  font-size: var(--th-text-body-sm-size);
+}
+
+ion-button:active {
+  --border-color: var(--th-primary-500);
+  --color: var(--th-primary-600);
+}
+
+ion-button ion-icon {
+  font-size: var(--th-text-body-sm-size);
+}
+
+/* Responsive Adjustments */
+@media (max-width: 1024px) {
+  .portal-hoteles-pricing-toolbar {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .portal-hoteles-pricing-toolbar__search {
+    grid-column: 1 / -1;
+  }
+
+  .portal-hoteles-pricing-toolbar__chip {
+    width: 100%;
+  }
+
+  .portal-hoteles-pricing-grid--panel {
+    grid-column: span 1;
+  }
+
+  .portal-hoteles-pricing-grid--sidebar {
+    grid-column: span 1;
+  }
+
+  .portal-hoteles-pricing-table__header,
+  .portal-hoteles-pricing-table__row {
+    grid-template-columns: minmax(100px, 1fr) repeat(4, minmax(80px, 1fr));
+  }
+
+  .portal-hoteles-pricing-table__room-type {
+    display: none;
+  }
+
+  .portal-hoteles-pricing-table__room-type-id {
+    display: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .portal-hoteles-pricing-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .portal-hoteles-pricing-grid--panel,
+  .portal-hoteles-pricing-grid--sidebar {
+    grid-column: span 1;
+  }
+
+  .portal-hoteles-pricing-table__header,
+  .portal-hoteles-pricing-table__row {
+    grid-template-columns: 1fr;
+  }
+
+  .portal-hoteles-pricing-table__capacity,
+  .portal-hoteles-pricing-table__base-rate,
+  .portal-hoteles-pricing-table__discount,
+  .portal-hoteles-pricing-table__final-rate,
+  .portal-hoteles-pricing-table__status,
+  .portal-hoteles-pricing-table__actions {
+    display: flex;
+  }
+
+  .portal-hoteles-pricing-table__room-type {
+    display: flex;
+  }
+
+  .portal-hoteles-pricing-table__room-type-id {
+    display: none;
+  }
+
+  .portal-hoteles-pricing-toolbar {
+    grid-template-columns: 1fr;
+  }
+}

--- a/user_interface/projects/portal-hoteles/src/app/pages/pricing-configuration/pricing-configuration.page.spec.ts
+++ b/user_interface/projects/portal-hoteles/src/app/pages/pricing-configuration/pricing-configuration.page.spec.ts
@@ -1,0 +1,254 @@
+/// <reference types="jasmine" />
+
+import { TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { AuthSessionService } from '@travelhub/core/services/auth-session.service';
+import { PricingEngineService } from '@travelhub/core/services/pricing-engine.service';
+import { PricingPropertyResponse } from '@travelhub/core/models/platform-api.model';
+import { PortalHotelesPricingConfigurationPage } from './pricing-configuration.page';
+
+describe('PortalHotelesPricingConfigurationPage', () => {
+  let component: PortalHotelesPricingConfigurationPage;
+  let pricingEngineServiceSpy: jasmine.SpyObj<PricingEngineService>;
+
+  const mockAuthSession = {
+    userEmail: 'test@example.com',
+  };
+
+  const emptyPricingResponse: PricingPropertyResponse = {
+    id: '',
+    name: '',
+    city: '',
+    country: '',
+    price: 0,
+    maxCapacity: 0,
+    description: '',
+    urlBucketPhotos: '',
+    checkInTime: '',
+    checkOutTime: '',
+    adminGroupId: '',
+  };
+
+  beforeEach(async () => {
+    pricingEngineServiceSpy = jasmine.createSpyObj<PricingEngineService>('PricingEngineService', ['getPropertyPricing']);
+
+    await TestBed.configureTestingModule({
+      imports: [PortalHotelesPricingConfigurationPage],
+      providers: [
+        { provide: AuthSessionService, useValue: mockAuthSession },
+        { provide: PricingEngineService, useValue: pricingEngineServiceSpy },
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(PortalHotelesPricingConfigurationPage);
+    component = fixture.componentInstance;
+  });
+
+  describe('Initial State', () => {
+    it('should initialize with empty pricing data', () => {
+      // Arrange
+
+      // Act
+
+      // Assert
+      expect(component.pricingData.name).toBe('');
+      expect(component.pricingData.city).toBe('');
+      expect(component.pricingData.country).toBe('');
+      expect(component.pricingData.price).toBe(0);
+      expect(component.pricingData.maxCapacity).toBe(0);
+      expect(component.isLoading).toBeFalse();
+    });
+
+    it('should initialize with default input values', () => {
+      // Arrange
+
+      // Act
+
+      // Assert
+      expect(component.propertyId).toBe('');
+      expect(component.guests).toBe(1);
+      expect(component.dateInit).toBe('');
+      expect(component.dateFinish).toBe('');
+      expect(component.currencyFilter).toBe('$');
+    });
+  });
+
+  describe('Loading Pricing Data', () => {
+    it('should load pricing data using default params when inputs are missing', async () => {
+      // Arrange
+      const mockData: PricingPropertyResponse = {
+        ...emptyPricingResponse,
+        id: '1',
+        name: 'Default Property',
+        price: 240,
+      };
+
+      component.propertyId = '';
+      component.guests = 0;
+      component.dateInit = '';
+      component.dateFinish = '';
+      pricingEngineServiceSpy.getPropertyPricing.and.returnValue(of(mockData));
+
+      // Act
+      await component.loadPricingData();
+
+      // Assert
+      expect(pricingEngineServiceSpy.getPropertyPricing).toHaveBeenCalled();
+      const requestArgs = pricingEngineServiceSpy.getPropertyPricing.calls.mostRecent().args[0];
+      expect(requestArgs.propertyId).toBe('7b2f2f2f-8a9b-4f25-ae6d-1d2a1f0c1c33');
+      expect(requestArgs.guests).toBe(1);
+      expect(requestArgs.dateInit).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(requestArgs.dateFinish).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(component.isLoading).toBeFalse();
+      expect(component.errorMessage).toBe('');
+    });
+
+    it('should load pricing data successfully', async () => {
+      // Arrange
+      const mockData: PricingPropertyResponse = {
+        id: '1',
+        name: 'Test Property',
+        city: 'Bogota',
+        country: 'Colombia',
+        price: 150,
+        maxCapacity: 4,
+        description: 'Luxury property',
+        urlBucketPhotos: '',
+        checkInTime: '14:00',
+        checkOutTime: '11:00',
+        adminGroupId: '',
+      };
+
+
+      component.propertyId = 'property-1';
+      component.guests = 2;
+      component.dateInit = '2026-05-10';
+      component.dateFinish = '2026-05-12';
+      pricingEngineServiceSpy.getPropertyPricing.and.returnValue(of(mockData));
+
+      // Act
+      await component.loadPricingData();
+
+      // Assert
+      expect(pricingEngineServiceSpy.getPropertyPricing).toHaveBeenCalledWith({
+        propertyId: 'property-1',
+        guests: 2,
+        dateInit: '2026-05-10',
+        dateFinish: '2026-05-12',
+      });
+      expect(component.pricingData.name).toBe('Test Property');
+      expect(component.pricingData.city).toBe('Bogota');
+      expect(component.pricingData.country).toBe('Colombia');
+      expect(component.pricingData.price).toBe(150);
+      expect(component.pricingData.maxCapacity).toBe(4);
+      expect(component.isLoading).toBeFalse();
+      expect(component.errorMessage).toBe('');
+    });
+
+    it('should handle loading error', async () => {
+      // Arrange
+      component.propertyId = 'property-1';
+      component.guests = 2;
+      component.dateInit = '2026-05-10';
+      component.dateFinish = '2026-05-12';
+      pricingEngineServiceSpy.getPropertyPricing.and.returnValue(
+        throwError(() => new Error('Network error')),
+      );
+
+      // Act
+      await component.loadPricingData();
+
+      // Assert
+      expect(component.isLoading).toBeFalse();
+      expect(component.errorMessage).toBe('Unable to load pricing data.');
+      expect(component.pricingData).toEqual(emptyPricingResponse);
+    });
+
+    it('returns range label when pricing data exists', () => {
+      // Arrange
+      component.pricingData = {
+        ...emptyPricingResponse,
+        id: '1',
+        name: 'Property',
+        price: 200,
+      };
+
+      // Act
+      const label = component.visibleRangeLabel;
+
+      // Assert
+      expect(label).toBe('Showing 1-1 of 1 pricing record');
+    });
+
+    it('returns fallback range label when no pricing data exists', () => {
+      // Arrange
+      component.pricingData = emptyPricingResponse;
+
+      // Act
+      const label = component.visibleRangeLabel;
+
+      // Assert
+      expect(label).toBe('No pricing data available');
+    });
+
+    it('should format rate correctly', () => {
+      // Arrange
+
+      // Act
+
+      // Assert
+      expect(component.formatRate(240, '$')).toBe('$240.00');
+      expect(component.formatRate(199.99, '$')).toBe('$199.99');
+    });
+
+    it('should format discount correctly', () => {
+      // Arrange
+
+      // Act
+
+      // Assert
+      expect(component.formatDiscount(-15)).toBe('-15.00% OFF');
+      expect(component.formatDiscount(35)).toBe('+35.00% OFF');
+      expect(component.formatDiscount(0)).toBe('No discount');
+      expect(component.formatDiscount(undefined)).toBe('No discount');
+    });
+
+    it('should format date range correctly', () => {
+      // Arrange
+
+      // Act
+
+      // Assert
+      expect(component.formatDateRange('Dec 15 - Jan 15')).toBe('Dec 15 - Jan 15');
+      expect(component.formatDateRange('')).toBe('-');
+    });
+
+    it('should get status class for active status', () => {
+      // Arrange
+
+      // Act
+
+      // Assert
+      expect(component.getStatusClass('Active')).toContain('portal-hoteles-pricing-status--active');
+    });
+
+    it('should get status class for inactive status', () => {
+      // Arrange
+
+      // Act
+
+      // Assert
+      expect(component.getStatusClass('Inactive')).toContain('portal-hoteles-pricing-status--inactive');
+    });
+
+    it('returns operator name from authenticated session', () => {
+      // Arrange
+
+      // Act
+      const operator = component.operatorName;
+
+      // Assert
+      expect(operator).toBe('test@example.com');
+    });
+  });
+});

--- a/user_interface/projects/portal-hoteles/src/app/pages/pricing-configuration/pricing-configuration.page.ts
+++ b/user_interface/projects/portal-hoteles/src/app/pages/pricing-configuration/pricing-configuration.page.ts
@@ -1,0 +1,319 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
+import { IonicModule } from '@ionic/angular';
+import { firstValueFrom } from 'rxjs';
+import { AuthSessionService } from '@travelhub/core/services/auth-session.service';
+import { PortalHotelesGridCardComponent } from '@travelhub/shared/components/portal-hoteles/grid-card/grid-card.component';
+import { RouterModule } from '@angular/router';
+import { PricingEngineService } from '@travelhub/core/services/pricing-engine.service';
+import { PricingPropertyResponse } from '@travelhub/core/models/platform-api.model';
+
+@Component({
+  selector: 'portal-hoteles-pricing-configuration',
+  templateUrl: './pricing-configuration.page.html',
+  styleUrls: ['./pricing-configuration.page.scss'],
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CommonModule, IonicModule, RouterModule, PortalHotelesGridCardComponent],
+})
+export class PortalHotelesPricingConfigurationPage implements OnInit {
+  private readonly defaultPropertyId = '7b2f2f2f-8a9b-4f25-ae6d-1d2a1f0c1c33';
+
+  @Input() propertyId = '';
+  @Input() guests = 1;
+  @Input() dateInit = '';
+  @Input() dateFinish = '';
+  @Input() currencyFilter = '$';
+
+  pricingData: PricingPropertyResponse = {
+    id: '',
+    name: '',
+    city: '',
+    country: '',
+    price: 0,
+    maxCapacity: 0,
+    description: '',
+    urlBucketPhotos: '',
+    checkInTime: '',
+    checkOutTime: '',
+    adminGroupId: '',
+  };
+
+  isLoading = false;
+  errorMessage = '';
+
+  roomRateRows: RoomRateRow[] = [];
+  seasonalRulesRows: SeasonalRuleRow[] = this.buildSeasonalRuleRows();
+
+  constructor(
+    private readonly authSession: AuthSessionService,
+    private readonly pricingEngineService: PricingEngineService,
+  ) {}
+
+  ngOnInit(): void {
+    this.refreshRoomRateRows();
+    this.loadPricingData();
+  }
+
+  get operatorName(): string {
+    return this.authSession.userEmail || 'Hotel Manager';
+  }
+
+  get visibleRangeLabel(): string {
+    if (!this.hasPricingData) {
+      return 'No pricing data available';
+    }
+
+    return 'Showing 1-1 of 1 pricing record';
+  }
+
+  get hasPricingData(): boolean {
+    return Boolean(this.pricingData.id && this.pricingData.price && this.pricingData.name);
+  }
+
+  getStatusClass(status: string): string {
+    const normalizedStatus = (status || '').trim().toLowerCase();
+    if (normalizedStatus === 'active') {
+      return 'portal-hoteles-pricing-status portal-hoteles-pricing-status--active';
+    }
+    return 'portal-hoteles-pricing-status portal-hoteles-pricing-status--inactive';
+  }
+
+  formatRate(rate: number, currency: string): string {
+    const formattedRate = new Intl.NumberFormat('en-US', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(rate) + currency;
+
+    return `${currency}${formattedRate.replace(currency, '')}`;
+  }
+
+  formatDiscount(discount: number | undefined): string {
+    if (discount == null || discount === 0) {
+      return 'No discount';
+    }
+
+    const percentage = Math.abs(discount).toFixed(2);
+    const sign = discount < 0 ? '-' : '+';
+    return `${sign}${percentage}% OFF`;
+  }
+
+  formatModifier(modifier: number): string {
+    const sign = modifier >= 0 ? '+' : '-';
+    return `${sign}${Math.abs(modifier)}%`;
+  }
+
+  getModifierClass(modifier: number): string {
+    if (modifier >= 0) {
+      return 'portal-hoteles-pricing-badge portal-hoteles-pricing-badge--danger';
+    }
+
+    return 'portal-hoteles-pricing-badge portal-hoteles-pricing-badge--success';
+  }
+
+  trackByRoomType(_index: number, row: RoomRateRow): string {
+    return row.roomTypeId;
+  }
+
+  trackBySeason(_index: number, row: SeasonalRuleRow): string {
+    return row.season;
+  }
+
+  private buildRoomRateRows(): RoomRateRow[] {
+    const baseRate = this.pricingData.price && this.pricingData.price > 0 ? this.pricingData.price : 240;
+
+    return [
+      {
+        roomType: 'Superior Double',
+        roomTypeId: 'Room Type 101',
+        capacityLabel: '2 guests',
+        baseRateLabel: this.formatRate(baseRate, this.currencyFilter),
+        discount: -15,
+        discountLabel: this.formatDiscount(-15),
+        discountClass: this.getModifierClass(-15),
+        finalRateLabel: this.formatRate(this.calculateFinalRate(baseRate, -15), this.currencyFilter),
+        status: 'Active',
+        statusClass: this.getStatusClass('Active'),
+      },
+      {
+        roomType: 'Deluxe Suite',
+        roomTypeId: 'Room Type 201',
+        capacityLabel: '4 guests',
+        baseRateLabel: this.formatRate(420, this.currencyFilter),
+        discount: 0,
+        discountLabel: this.formatDiscount(0),
+        discountClass: this.getModifierClass(0),
+        finalRateLabel: this.formatRate(420, this.currencyFilter),
+        status: 'Active',
+        statusClass: this.getStatusClass('Active'),
+      },
+      {
+        roomType: 'Standard Room',
+        roomTypeId: 'Room Type 001',
+        capacityLabel: '2 guests',
+        baseRateLabel: this.formatRate(180, this.currencyFilter),
+        discount: -10,
+        discountLabel: this.formatDiscount(-10),
+        discountClass: this.getModifierClass(-10),
+        finalRateLabel: this.formatRate(this.calculateFinalRate(180, -10), this.currencyFilter),
+        status: 'Active',
+        statusClass: this.getStatusClass('Active'),
+      },
+      {
+        roomType: 'Junior Suite',
+        roomTypeId: 'Room Type 301',
+        capacityLabel: '3 guests',
+        baseRateLabel: this.formatRate(320, this.currencyFilter),
+        discount: -20,
+        discountLabel: this.formatDiscount(-20),
+        discountClass: this.getModifierClass(-20),
+        finalRateLabel: this.formatRate(this.calculateFinalRate(320, -20), this.currencyFilter),
+        status: 'Active',
+        statusClass: this.getStatusClass('Active'),
+      },
+    ];
+  }
+
+  private buildSeasonalRuleRows(): SeasonalRuleRow[] {
+    return [
+      {
+        season: 'High Season',
+        description: 'Summer & Holidays',
+        dateRange: 'Dec 15 - Jan 15',
+        helperDateRange: 'Jun 15 - Aug 31',
+        modifier: 35,
+        modifierLabel: this.formatModifier(35),
+        modifierClass: this.getModifierClass(35),
+        status: 'Active',
+        statusClass: this.getStatusClass('Active'),
+      },
+      {
+        season: 'Low Season',
+        description: 'Off-peak periods',
+        dateRange: 'Feb 1 - May 31',
+        helperDateRange: 'Sep 15 - Nov 30',
+        modifier: -20,
+        modifierLabel: this.formatModifier(-20),
+        modifierClass: this.getModifierClass(-20),
+        status: 'Active',
+        statusClass: this.getStatusClass('Active'),
+      },
+    ];
+  }
+
+  private refreshRoomRateRows(): void {
+    this.roomRateRows = this.buildRoomRateRows();
+  }
+
+  private calculateFinalRate(baseRate: number, discount: number): number {
+    if (!discount) {
+      return baseRate;
+    }
+
+    return Math.round(baseRate * (1 + discount / 100));
+  }
+
+  formatDateRange(dateRange: string): string {
+    if (!dateRange) {
+      return '-';
+    }
+    try {
+      const parts = dateRange.split(' - ');
+      if (parts.length === 2) {
+        const start = new Date(parts[0]);
+        const end = new Date(parts[1]);
+        const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+        const startMonth = months[start.getMonth()];
+        const endMonth = months[end.getMonth()];
+        return `${startMonth} ${start.getDate()} - ${endMonth} ${end.getDate()}`;
+      }
+    } catch {
+      // Ignore errors
+    }
+    return dateRange || '-';
+  }
+
+  async loadPricingData(): Promise<void> {
+    this.isLoading = true;
+    this.errorMessage = '';
+
+    try {
+      const params = this.buildPricingQuery();
+
+      const data = await firstValueFrom(
+        this.pricingEngineService.getPropertyPricing(params),
+      );
+
+      this.pricingData = data as PricingPropertyResponse;
+      this.refreshRoomRateRows();
+    } catch {
+      this.errorMessage = 'Unable to load pricing data.';
+      this.pricingData = {
+        id: '',
+        name: '',
+        city: '',
+        country: '',
+        price: 0,
+        maxCapacity: 0,
+        description: '',
+        urlBucketPhotos: '',
+        checkInTime: '',
+        checkOutTime: '',
+        adminGroupId: '',
+      };
+      this.refreshRoomRateRows();
+    } finally {
+      this.isLoading = false;
+    }
+  }
+
+  private buildPricingQuery(): {
+    propertyId: string;
+    guests: number;
+    dateInit: string;
+    dateFinish: string;
+  } {
+    return {
+      propertyId: this.propertyId || this.defaultPropertyId,
+      guests: this.guests > 0 ? this.guests : 1,
+      dateInit: this.dateInit || this.todayIsoDate(),
+      dateFinish: this.dateFinish || this.tomorrowIsoDate(),
+    };
+  }
+
+  private todayIsoDate(): string {
+    const currentDate = new Date();
+    return currentDate.toISOString().slice(0, 10);
+  }
+
+  private tomorrowIsoDate(): string {
+    const currentDate = new Date();
+    currentDate.setDate(currentDate.getDate() + 1);
+    return currentDate.toISOString().slice(0, 10);
+  }
+}
+
+interface RoomRateRow {
+  roomType: string;
+  roomTypeId: string;
+  capacityLabel: string;
+  baseRateLabel: string;
+  discount: number;
+  discountLabel: string;
+  discountClass: string;
+  finalRateLabel: string;
+  status: string;
+  statusClass: string;
+}
+
+interface SeasonalRuleRow {
+  season: string;
+  description: string;
+  dateRange: string;
+  helperDateRange: string;
+  modifier: number;
+  modifierLabel: string;
+  modifierClass: string;
+  status: string;
+  statusClass: string;
+}

--- a/user_interface/projects/portal-hoteles/src/app/pages/reports/reports.page.html
+++ b/user_interface/projects/portal-hoteles/src/app/pages/reports/reports.page.html
@@ -1,0 +1,142 @@
+<ion-content class="portal-hoteles-reports-content">
+  <section class="portal-hoteles-reports-hero">
+    <h1 class="portal-hoteles-reports-hero__kicker">Incoming Report</h1>
+    <p>Welcome back! Here's what's happening at your hotel today.</p>
+  </section>
+
+  <section class="portal-hoteles-reports-grid portal-hoteles-reports-grid--kpi">
+    <portal-hoteles-grid-card
+      cardClass="portal-hoteles-grid-card--metric"
+      *ngFor="let card of kpiCards"
+    >
+      <div class="portal-hoteles-reports-kpi">
+        <div>
+          <span class="portal-hoteles-reports-kpi__label">{{ card.label }}</span>
+          <strong class="portal-hoteles-reports-kpi__value">{{ card.value }}</strong>
+          <p [class]="'portal-hoteles-reports-kpi__trend ' + card.trendClass">{{ card.trend }}</p>
+        </div>
+        <div class="portal-hoteles-reports-kpi__badge" aria-hidden="true">
+          <ion-icon class="portal-hoteles-reports-kpi__icon" [name]="card.icon"></ion-icon>
+        </div>
+      </div>
+    </portal-hoteles-grid-card>
+  </section>
+
+  <section class="portal-hoteles-reports-grid portal-hoteles-reports-grid--content portal-hoteles-reports-grid--full-width">
+    <portal-hoteles-revenue-chart-card
+      title="Revenue Overview"
+      subtitle="Visual revenue trend by month"
+      [periodLabel]="chartPeriod"
+      [periodOptions]="chartPeriodOptions"
+      [categories]="chartCategories"
+      [values]="chartValues"
+      [yAxisTicks]="chartTicks"
+      [ariaDescription]="'Revenue overview chart for period ' + chartPeriod"
+      (periodChange)="onChartPeriodChange($event)"
+    ></portal-hoteles-revenue-chart-card>
+
+    <portal-hoteles-grid-card
+      cardClass="portal-hoteles-grid-card--panel portal-hoteles-grid-card--wide"
+      title="Daily Revenue Report"
+      subtitle="Detailed transactions and payment status"
+    >
+      <div slot="header-actions" class="portal-hoteles-reports-toolbar-header" role="group" aria-label="Report filters and export options">
+        <div class="portal-hoteles-reports-toolbar-header__filters">
+          <ion-select
+            class="portal-hoteles-reports-toolbar-header__select"
+            interface="popover"
+            [value]="selectedTablePeriod"
+            aria-label="Filter report period"
+            (ionChange)="onTablePeriodChange($event.detail.value)"
+          >
+            <ion-select-option *ngFor="let period of tablePeriodOptions" [value]="period">{{ period }}</ion-select-option>
+          </ion-select>
+
+          <ion-select
+            class="portal-hoteles-reports-toolbar-header__select"
+            interface="popover"
+            [value]="selectedCurrency"
+            aria-label="Select report currency"
+            (ionChange)="onCurrencyChange($event.detail.value)"
+          >
+            <ion-select-option *ngFor="let currency of currencyOptions" [value]="currency">{{ currency }}</ion-select-option>
+          </ion-select>
+        </div>
+
+        <div class="portal-hoteles-reports-toolbar-header__export">
+          <ion-button
+            size="small"
+            fill="outline"
+            class="portal-hoteles-reports-toolbar-header__export-button portal-hoteles-reports-toolbar-header__export-button--secondary"
+          >
+            PDF
+          </ion-button>
+          <ion-button
+            size="small"
+            fill="solid"
+            class="portal-hoteles-reports-toolbar-header__export-button portal-hoteles-reports-toolbar-header__export-button--primary"
+          >
+            Excel
+          </ion-button>
+        </div>
+      </div>
+
+      <table class="portal-hoteles-reports-table" *ngIf="hasRows; else noRowsTemplate">
+        <thead>
+          <tr class="portal-hoteles-reports-table__header">
+            <th scope="col">Date</th>
+            <th scope="col">Booking ID</th>
+            <th scope="col">Guest</th>
+            <th scope="col">Room Type</th>
+            <th scope="col">Payment</th>
+            <th scope="col">Amount</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="portal-hoteles-reports-table__row" *ngFor="let row of visibleRows">
+            <td>{{ row.dateLabel }}</td>
+            <td>#{{ row.bookingId }}</td>
+            <td>{{ row.guestLabel }}</td>
+            <td>{{ row.roomLabel }}</td>
+            <td>
+              <span [class]="getPaymentStatusClass(row.paymentStatus)">{{ row.paymentStatus }}</span>
+            </td>
+            <td>{{ formatAmount(row.amount) }}</td>
+          </tr>
+        </tbody>
+        <tfoot>
+          <tr>
+            <td colspan="6" class="portal-hoteles-reports-table__footer">
+              <span>{{ rangeLabel }}</span>
+              <div class="portal-hoteles-reports-table__pagination" *ngIf="shouldShowPagination">
+                <ion-button
+                  fill="outline"
+                  size="small"
+                  class="portal-hoteles-reports-table__pagination-button"
+                  [disabled]="!canGoToPreviousPage"
+                  (click)="onPreviousPage()"
+                >
+                  Previous
+                </ion-button>
+                <span class="portal-hoteles-reports-table__pagination-label">{{ paginationLabel }}</span>
+                <ion-button
+                  fill="outline"
+                  size="small"
+                  class="portal-hoteles-reports-table__pagination-button"
+                  [disabled]="!canGoToNextPage"
+                  (click)="onNextPage()"
+                >
+                  Next
+                </ion-button>
+              </div>
+            </td>
+          </tr>
+        </tfoot>
+      </table>
+
+      <ng-template #noRowsTemplate>
+        <p class="portal-hoteles-reports-table__message" aria-live="polite" aria-atomic="true">No revenue transactions available.</p>
+      </ng-template>
+    </portal-hoteles-grid-card>
+  </section>
+</ion-content>

--- a/user_interface/projects/portal-hoteles/src/app/pages/reports/reports.page.scss
+++ b/user_interface/projects/portal-hoteles/src/app/pages/reports/reports.page.scss
@@ -1,0 +1,297 @@
+.portal-hoteles-reports-content {
+  --background: transparent;
+  --color: var(--th-neutral-900);
+  color: var(--th-neutral-900);
+}
+
+.portal-hoteles-reports-hero {
+  width: min(100%, 960px);
+  margin: 0 auto;
+  padding: 0 0 var(--th-space-6);
+}
+
+.portal-hoteles-reports-hero__kicker {
+  padding-top: var(--th-space-5);
+  margin: 0 0 var(--th-space-2);
+  color: var(--th-primary-700);
+  font-size: var(--th-text-caption-size);
+  font-weight: var(--th-font-weight-semibold);
+}
+
+.portal-hoteles-reports-hero h1 {
+  margin: 0;
+  color: var(--th-neutral-900);
+  font-size: var(--th-text-h1-size);
+  line-height: 1.1;
+}
+
+.portal-hoteles-reports-hero p {
+  margin: var(--th-space-2) 0 0;
+  color: var(--th-neutral-700);
+}
+
+.portal-hoteles-reports-grid {
+  display: grid;
+  gap: var(--th-space-4);
+}
+
+.portal-hoteles-reports-grid--full-width {
+  grid-template-columns: minmax(0, 0.8fr);
+  justify-content: center;
+}
+
+.portal-hoteles-reports-grid--kpi {
+  width: min(100%, 960px);
+  margin: 0 auto;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  padding: 0 0 var(--th-space-4);
+}
+
+.portal-hoteles-reports-grid--content {
+  padding: 0 0 var(--th-space-8);
+}
+
+.portal-hoteles-reports-kpi {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--th-space-3);
+}
+
+.portal-hoteles-reports-kpi__label {
+  display: block;
+  color: var(--th-neutral-700);
+  font-size: var(--th-text-body-sm-size);
+}
+
+.portal-hoteles-reports-kpi__value {
+  display: block;
+  margin-top: var(--th-space-2);
+  color: var(--th-neutral-900);
+  font-size: var(--th-text-h1-size);
+  line-height: 1;
+}
+
+.portal-hoteles-reports-kpi__trend {
+  margin: var(--th-space-2) 0 0;
+  font-size: var(--th-text-body-sm-size);
+}
+
+.portal-hoteles-reports-kpi__trend--positive {
+  color: var(--th-success-700);
+}
+
+.portal-hoteles-reports-kpi__icon {
+  font-size: 20px;
+  color: var(--th-primary-700);
+}
+
+.portal-hoteles-reports-kpi__badge {
+  background: var(--th-primary-50);
+  border: 1px solid var(--th-primary-100);
+  border-radius: var(--th-radius-full);
+  padding: var(--th-space-2) var(--th-space-3);
+}
+
+.portal-hoteles-reports-toolbar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--th-space-3);
+  border: 1px solid var(--th-neutral-300);
+  border-radius: var(--th-radius-md);
+  background: var(--th-white);
+  padding: var(--th-space-2);
+}
+
+.portal-hoteles-reports-toolbar-header__filters {
+  display: flex;
+  align-items: center;
+  gap: var(--th-space-2);
+}
+
+.portal-hoteles-reports-toolbar-header__select {
+  --background: var(--th-white);
+  --border-color: var(--th-neutral-300);
+  --border-style: solid;
+  --border-width: 1px;
+  --border-radius: var(--th-radius-md);
+  --padding-start: 10px;
+  min-width: 140px;
+}
+
+.portal-hoteles-reports-toolbar-header__export {
+  display: inline-flex;
+  align-items: stretch;
+  overflow: hidden;
+  border: 1px solid var(--th-neutral-300);
+  border-radius: var(--th-radius-md);
+  background: var(--th-white);
+}
+
+.portal-hoteles-reports-toolbar-header__export-button {
+  margin: 0;
+  min-height: 30px;
+  --border-radius: 0;
+  --padding-start: 14px;
+  --padding-end: 14px;
+  text-transform: none;
+  font-size: var(--th-text-body-sm-size);
+}
+
+.portal-hoteles-reports-toolbar-header__export-button--secondary {
+  --background: var(--th-white);
+  --background-hover: var(--th-neutral-50);
+  --color: var(--th-neutral-700);
+  --border-color: transparent;
+}
+
+.portal-hoteles-reports-toolbar-header__export-button--primary {
+  --background: var(--th-primary-700);
+  --background-hover: var(--th-primary-800);
+  --color: var(--th-white);
+  --border-color: transparent;
+}
+
+.portal-hoteles-reports-table {
+  display: flex;
+  flex-direction: column;
+  gap: var(--th-space-3);
+}
+
+.portal-hoteles-reports-table__header,
+.portal-hoteles-reports-table__row {
+  display: grid;
+  grid-template-columns: minmax(100px, 1fr) minmax(110px, 0.9fr) minmax(140px, 1fr) minmax(130px, 1fr) minmax(100px, 0.9fr) minmax(90px, 0.8fr);
+  align-items: center;
+  gap: var(--th-space-3);
+  border: 1px solid var(--th-neutral-300);
+  border-radius: var(--th-radius-lg);
+  background: var(--th-white);
+}
+
+.portal-hoteles-reports-table__header {
+  min-height: 40px;
+  padding: 0 var(--th-space-4);
+  font-size: var(--th-text-overline-size);
+  font-weight: var(--th-font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--th-neutral-600);
+}
+
+.portal-hoteles-reports-table__row {
+  min-height: 68px;
+  padding: var(--th-space-3) var(--th-space-4);
+  color: var(--th-neutral-900);
+  font-size: var(--th-text-body-sm-size);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.portal-hoteles-reports-table__row:hover {
+  border-color: var(--th-primary-200);
+  box-shadow: 0 8px 16px rgba(20, 53, 88, 0.08);
+}
+
+.portal-hoteles-reports-table-status {
+  display: inline-flex;
+  justify-content: center;
+  min-width: 86px;
+  border-radius: var(--th-radius-full);
+  padding: var(--th-space-1) var(--th-space-3);
+  font-size: var(--th-text-caption-size);
+  font-weight: var(--th-font-weight-medium);
+}
+
+.portal-hoteles-reports-table-status--paid {
+  color: var(--th-success-700);
+  background: var(--th-success-50);
+}
+
+.portal-hoteles-reports-table-status--pending {
+  color: var(--th-warning-700);
+  background: var(--th-warning-50);
+}
+
+.portal-hoteles-reports-table-status--failed {
+  color: var(--th-error-700);
+  background: var(--th-error-50);
+}
+
+.portal-hoteles-reports-table-status--refunded,
+.portal-hoteles-reports-table-status--default {
+  color: var(--th-neutral-700);
+  background: var(--th-neutral-100);
+}
+
+.portal-hoteles-reports-table__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--th-space-3);
+  color: var(--th-neutral-700);
+  font-size: var(--th-text-body-sm-size);
+}
+
+.portal-hoteles-reports-table__pagination {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--th-space-2);
+}
+
+.portal-hoteles-reports-table__pagination-button {
+  --border-color: var(--th-neutral-300);
+  --color: var(--th-neutral-700);
+  --padding-start: 12px;
+  --padding-end: 12px;
+  font-size: var(--th-text-body-sm-size);
+  text-transform: none;
+}
+
+.portal-hoteles-reports-table__pagination-label {
+  min-width: 96px;
+  text-align: center;
+  color: var(--th-neutral-700);
+}
+
+.portal-hoteles-reports-table__message {
+  margin: var(--th-space-4) 0 0;
+  color: var(--th-neutral-700);
+}
+
+@media (max-width: 1200px) {
+  .portal-hoteles-reports-grid--kpi {
+    grid-template-columns: 1fr;
+  }
+
+  .portal-hoteles-reports-table__header,
+  .portal-hoteles-reports-table__row {
+    grid-template-columns: 1fr;
+    gap: var(--th-space-2);
+  }
+
+  .portal-hoteles-reports-table__header {
+    display: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .portal-hoteles-reports-table-toolbar {
+    flex-wrap: wrap;
+  }
+
+  .portal-hoteles-reports-table-toolbar__select,
+  .portal-hoteles-reports-table-toolbar__export {
+    width: 100%;
+  }
+
+  .portal-hoteles-reports-table__footer {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .portal-hoteles-reports-table__pagination {
+    width: 100%;
+    justify-content: space-between;
+  }
+}

--- a/user_interface/projects/portal-hoteles/src/app/pages/reports/reports.page.spec.ts
+++ b/user_interface/projects/portal-hoteles/src/app/pages/reports/reports.page.spec.ts
@@ -1,0 +1,121 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PortalHotelesReportsPage } from './reports.page';
+
+describe('PortalHotelesReportsPage', () => {
+  let component: PortalHotelesReportsPage;
+  let fixture: ComponentFixture<PortalHotelesReportsPage>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PortalHotelesReportsPage],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PortalHotelesReportsPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('creates the reports page scaffold', () => {
+    // Arrange
+
+    // Act
+    const createdComponent = component;
+
+    // Assert
+    expect(createdComponent).toBeTruthy();
+  });
+
+  it('renders the reports heading', () => {
+    // Arrange
+
+    // Act
+    const element = fixture.nativeElement as HTMLElement;
+
+    // Assert
+    expect(element.textContent).toContain('Incoming Report');
+    expect(element.textContent).toContain("Welcome back! Here's what's happening at your hotel today.");
+  });
+
+  it('renders kpi cards and first page rows', () => {
+    // Arrange
+
+    // Act
+    const element = fixture.nativeElement as HTMLElement;
+    const kpiCards = element.querySelectorAll('.portal-hoteles-reports-kpi');
+    const rows = element.querySelectorAll('.portal-hoteles-reports-table__row');
+
+    // Assert
+    expect(kpiCards.length).toBe(2);
+    expect(rows.length).toBe(5);
+    expect(element.textContent).toContain('Avg. Daily Revenue');
+    expect(element.textContent).toContain('Monthly Revenue');
+    expect(element.textContent).toContain('PDF');
+    expect(element.textContent).toContain('Excel');
+  });
+
+  it('moves to next page and updates range/pagination labels', () => {
+    // Arrange
+
+    // Act
+    component.onNextPage();
+    fixture.detectChanges();
+
+    // Assert
+    expect(component.paginationLabel).toBe('Page 2 of 2');
+    expect(component.rangeLabel).toBe('Showing 6-6 of 6 transactions');
+    expect(component.visibleRows.length).toBe(1);
+  });
+
+  it('returns expected payment status classes', () => {
+    // Arrange
+
+    // Act
+    const paidClass = component.getPaymentStatusClass('Paid');
+    const pendingClass = component.getPaymentStatusClass('Pending');
+    const failedClass = component.getPaymentStatusClass('Failed');
+    const unknownClass = component.getPaymentStatusClass('Other');
+
+    // Assert
+    expect(paidClass).toContain('--paid');
+    expect(pendingClass).toContain('--pending');
+    expect(failedClass).toContain('--failed');
+    expect(unknownClass).toContain('--default');
+  });
+
+  it('updates table period when a valid option is selected', () => {
+    // Arrange
+
+    // Act
+    component.onTablePeriodChange('Last 30 days');
+
+    // Assert
+    expect(component.selectedTablePeriod).toBe('Last 30 days');
+  });
+
+  it('updates currency when a valid option is selected', () => {
+    // Arrange
+
+    // Act
+    component.onCurrencyChange('COP');
+
+    // Assert
+    expect(component.selectedCurrency).toBe('COP');
+  });
+
+  it('renders empty message when no rows exist', () => {
+    // Arrange
+    const emptyFixture = TestBed.createComponent(PortalHotelesReportsPage);
+    const emptyComponent = emptyFixture.componentInstance;
+    emptyComponent.reportRows = [];
+
+    // Act
+    emptyFixture.detectChanges();
+    const element = emptyFixture.nativeElement as HTMLElement;
+
+    // Assert
+    expect(element.textContent).toContain('No revenue transactions available.');
+    expect(emptyComponent.hasRows).toBeFalse();
+    expect(emptyComponent.rangeLabel).toBe('Showing 0-0 of 0 transactions');
+  });
+});

--- a/user_interface/projects/portal-hoteles/src/app/pages/reports/reports.page.ts
+++ b/user_interface/projects/portal-hoteles/src/app/pages/reports/reports.page.ts
@@ -1,0 +1,229 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { IonicModule } from '@ionic/angular';
+import { PortalHotelesGridCardComponent } from '@travelhub/shared/components/portal-hoteles/grid-card/grid-card.component';
+import { PortalHotelesRevenueChartCardComponent } from '@travelhub/shared/components/portal-hoteles/revenue-chart-card/revenue-chart-card.component';
+
+@Component({
+  selector: 'portal-hoteles-reports',
+  templateUrl: './reports.page.html',
+  styleUrls: ['./reports.page.scss'],
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    CommonModule,
+    IonicModule,
+    PortalHotelesGridCardComponent,
+    PortalHotelesRevenueChartCardComponent,
+  ],
+})
+export class PortalHotelesReportsPage {
+  private readonly pageSize = 5;
+  private currentPage = 1;
+
+  readonly chartPeriodOptions = ['Last 6 months', 'Last 12 months'];
+  readonly tablePeriodOptions = ['Last 7 days', 'Last 30 days'];
+  readonly currencyOptions = ['USD', 'EUR', 'COP'];
+
+  chartPeriod = 'Last 6 months';
+  selectedTablePeriod = 'Last 7 days';
+  selectedCurrency = 'USD';
+
+  readonly kpiCards: ReportKpiCard[] = [
+    {
+      label: 'Avg. Daily Revenue',
+      value: '$4,760',
+      trend: '+8.5% from previous week',
+      trendClass: 'portal-hoteles-reports-kpi__trend--positive',
+      icon: 'analytics-outline',
+    },
+    {
+      label: 'Monthly Revenue',
+      value: '$142,980',
+      trend: '+14.2% from previous month',
+      trendClass: 'portal-hoteles-reports-kpi__trend--positive',
+      icon: 'cash-outline',
+    },
+  ];
+
+  readonly chartCategories = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'];
+  readonly chartValues = [72000, 84000, 91000, 88000, 103000, 112000];
+  readonly chartTicks = [120000, 90000, 60000, 30000, 0];
+
+  reportRows: DailyRevenueRow[] = [
+    {
+      dateLabel: 'Apr 22, 2026',
+      bookingId: 'BK-24891',
+      guestLabel: 'Emily Carter',
+      roomLabel: 'Deluxe Suite',
+      paymentStatus: 'Paid',
+      amount: 540,
+    },
+    {
+      dateLabel: 'Apr 22, 2026',
+      bookingId: 'BK-24892',
+      guestLabel: 'Daniel Morgan',
+      roomLabel: 'Standard Room',
+      paymentStatus: 'Pending',
+      amount: 220,
+    },
+    {
+      dateLabel: 'Apr 23, 2026',
+      bookingId: 'BK-24893',
+      guestLabel: 'Sophia Taylor',
+      roomLabel: 'Superior Double',
+      paymentStatus: 'Paid',
+      amount: 310,
+    },
+    {
+      dateLabel: 'Apr 23, 2026',
+      bookingId: 'BK-24894',
+      guestLabel: 'Liam Robinson',
+      roomLabel: 'Junior Suite',
+      paymentStatus: 'Failed',
+      amount: 460,
+    },
+    {
+      dateLabel: 'Apr 24, 2026',
+      bookingId: 'BK-24895',
+      guestLabel: 'Olivia Diaz',
+      roomLabel: 'Deluxe Suite',
+      paymentStatus: 'Paid',
+      amount: 520,
+    },
+    {
+      dateLabel: 'Apr 24, 2026',
+      bookingId: 'BK-24896',
+      guestLabel: 'Noah Kim',
+      roomLabel: 'Standard Room',
+      paymentStatus: 'Refunded',
+      amount: 190,
+    },
+  ];
+
+  get visibleRows(): DailyRevenueRow[] {
+    const startIndex = (this.currentPage - 1) * this.pageSize;
+    const endIndex = startIndex + this.pageSize;
+    return this.reportRows.slice(startIndex, endIndex);
+  }
+
+  get hasRows(): boolean {
+    return this.visibleRows.length > 0;
+  }
+
+  get totalRows(): number {
+    return this.reportRows.length;
+  }
+
+  get totalPages(): number {
+    if (!this.totalRows) {
+      return 1;
+    }
+
+    return Math.ceil(this.totalRows / this.pageSize);
+  }
+
+  get canGoToPreviousPage(): boolean {
+    return this.currentPage > 1;
+  }
+
+  get canGoToNextPage(): boolean {
+    return this.currentPage < this.totalPages;
+  }
+
+  get paginationLabel(): string {
+    return `Page ${this.currentPage} of ${this.totalPages}`;
+  }
+
+  get rangeLabel(): string {
+    if (!this.totalRows) {
+      return 'Showing 0-0 of 0 transactions';
+    }
+
+    const start = (this.currentPage - 1) * this.pageSize + 1;
+    const end = start + this.visibleRows.length - 1;
+    return `Showing ${start}-${end} of ${this.totalRows} transactions`;
+  }
+
+  get shouldShowPagination(): boolean {
+    return this.totalRows > this.pageSize;
+  }
+
+  onChartPeriodChange(nextPeriod: string): void {
+    this.chartPeriod = nextPeriod;
+  }
+
+  onTablePeriodChange(nextPeriod: string): void {
+    if (!nextPeriod) {
+      return;
+    }
+
+    this.selectedTablePeriod = nextPeriod;
+  }
+
+  onCurrencyChange(nextCurrency: string): void {
+    if (!nextCurrency) {
+      return;
+    }
+
+    this.selectedCurrency = nextCurrency;
+  }
+
+  onPreviousPage(): void {
+    if (!this.canGoToPreviousPage) {
+      return;
+    }
+
+    this.currentPage -= 1;
+  }
+
+  onNextPage(): void {
+    if (!this.canGoToNextPage) {
+      return;
+    }
+
+    this.currentPage += 1;
+  }
+
+  formatAmount(value: number): string {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      maximumFractionDigits: 0,
+    }).format(value);
+  }
+
+  getPaymentStatusClass(status: string): string {
+    const normalizedStatus = (status || '').trim().toLowerCase();
+
+    switch (normalizedStatus) {
+      case 'paid':
+        return 'portal-hoteles-reports-table-status portal-hoteles-reports-table-status--paid';
+      case 'pending':
+        return 'portal-hoteles-reports-table-status portal-hoteles-reports-table-status--pending';
+      case 'failed':
+        return 'portal-hoteles-reports-table-status portal-hoteles-reports-table-status--failed';
+      case 'refunded':
+        return 'portal-hoteles-reports-table-status portal-hoteles-reports-table-status--refunded';
+      default:
+        return 'portal-hoteles-reports-table-status portal-hoteles-reports-table-status--default';
+    }
+  }
+}
+
+interface ReportKpiCard {
+  label: string;
+  value: string;
+  trend: string;
+  trendClass: string;
+  icon: string;
+}
+
+interface DailyRevenueRow {
+  dateLabel: string;
+  bookingId: string;
+  guestLabel: string;
+  roomLabel: string;
+  paymentStatus: string;
+  amount: number;
+}

--- a/user_interface/src/app/core/models/platform-api.model.ts
+++ b/user_interface/src/app/core/models/platform-api.model.ts
@@ -29,4 +29,10 @@ export interface PricingPropertyResponse {
   city?: string;
   country?: string;
   price?: number;
+  maxCapacity?: number;
+  description?: string;
+  urlBucketPhotos?: string;
+  checkInTime?: string;
+  checkOutTime?: string;
+  adminGroupId?: string;
 }

--- a/user_interface/src/app/core/models/pricing.model.ts
+++ b/user_interface/src/app/core/models/pricing.model.ts
@@ -1,3 +1,71 @@
+export interface RoomType {
+  id: string;
+  name: string;
+  roomTypeId: string;
+  capacity: number;
+  baseRate: number;
+  currency: string;
+  discount?: number;
+  finalRate: number;
+  status: 'Active' | 'Inactive';
+  actions?: {
+    edit: () => void;
+    delete: () => void;
+  };
+}
+
+export interface SeasonalRule {
+  id: string;
+  season: string;
+  dateRange: string;
+  modifier: number;
+  status: 'Active' | 'Inactive';
+  actions?: {
+    edit: () => void;
+    delete: () => void;
+  };
+}
+
+export interface PricingData {
+  roomTypes: RoomType[];
+  seasonalRules: SeasonalRule[];
+  isLoading: boolean;
+  errorMessage?: string;
+}
+
+export interface PricingFilters {
+  roomType?: string;
+  currency?: string;
+  season?: string;
+}
+
+export interface PricingTableData {
+  roomType: string;
+  capacity: string;
+  baseRate: string;
+  discount: string;
+  finalRate: string;
+  status: string;
+  actions: string[];
+}
+
+export interface SeasonalTableData {
+  season: string;
+  dateRange: string;
+  modifier: string;
+  status: string;
+  actions: string[];
+}
+
+// Query parameters sent to the Pricing Orchestrator API
+// export interface PropertyPriceQuery {
+//   propertyId: string;
+//   guests: number;
+//   dateInit: string; // ISO 8601
+//   dateFinish: string; // ISO 8601
+//   discountCode?: string;
+// }
+
 export interface PricingOrchestratorResponse {
   id: string;
   name: string;
@@ -11,3 +79,14 @@ export interface PricingOrchestratorResponse {
 }
 
 export { PropertyPriceQuery } from './platform-api.model';
+
+// Minimal shape for the Pricing Orchestrator response used by the UI
+// export interface PricingOrchestratorResponse {
+//   propertyId: string;
+//   currency: string;
+//   totalPrice: number; // total price for the requested date range
+//   // Backwards-compatible alias for older code that expects `price`
+//   price?: number;
+//   perNight?: Array<{ date: string; price: number }>;
+//   breakdown?: Record<string, unknown>;
+// }

--- a/user_interface/src/app/core/services/pricing-engine.service.spec.ts
+++ b/user_interface/src/app/core/services/pricing-engine.service.spec.ts
@@ -1,0 +1,174 @@
+/// <reference types="jasmine" />
+
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { ConfigService } from './config.service';
+import { PricingEngineService } from './pricing-engine.service';
+
+describe('PricingEngineService', () => {
+  let service: PricingEngineService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        PricingEngineService,
+        {
+          provide: ConfigService,
+          useValue: {
+            apiBaseUrl: 'https://api.example.com',
+            propertyApiPath: '/poc-properties/api/property',
+            propertyApiToken: 'property-token',
+          },
+        },
+      ],
+    });
+
+    service = TestBed.inject(PricingEngineService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('gets pricing engine health', () => {
+    service.getPricingEngineHealth().subscribe((response) => {
+      expect(response.status).toBe('ok');
+    });
+
+    const req = httpMock.expectOne('https://api.example.com/pricing-engine/api/Health');
+    expect(req.request.method).toBe('GET');
+
+    req.flush({ status: 'ok', service: 'pricing-engine' });
+  });
+
+  it('gets pricing engine property price with query params', () => {
+    service.getPricingEnginePropertyPrice({
+      propertyId: '7b2f2f2f-8a9b-4f25-ae6d-1d2a1f0c1c33',
+      guests: 2,
+      dateInit: '2026-05-10',
+      dateFinish: '2026-05-12',
+      discountCode: 'SPRING',
+    }).subscribe((response) => {
+      expect(response.price).toBe(560000);
+    });
+
+    const req = httpMock.expectOne((request) => {
+      return request.url === 'https://api.example.com/pricing-engine/api/PropertyPrice'
+        && request.params.get('propertyId') === '7b2f2f2f-8a9b-4f25-ae6d-1d2a1f0c1c33'
+        && request.params.get('guests') === '2'
+        && request.params.get('dateInit') === '2026-05-10'
+        && request.params.get('dateFinish') === '2026-05-12'
+        && request.params.get('discountCode') === 'SPRING';
+    });
+
+    expect(req.request.method).toBe('GET');
+    req.flush({ id: '7b2f2f2f-8a9b-4f25-ae6d-1d2a1f0c1c33', price: 560000 });
+  });
+
+  it('gets pricing orchestrator health', () => {
+    service.getPricingOrchestratorHealth().subscribe((response) => {
+      expect(response.status).toBe('ok');
+    });
+
+    const req = httpMock.expectOne('https://api.example.com/pricing-orchestator/api/Health');
+    expect(req.request.method).toBe('GET');
+
+    req.flush({ status: 'ok', service: 'pricing-orchestator' });
+  });
+
+  it('gets pricing orchestrator property with query params', () => {
+    service.getPricingOrchestratorProperty({
+      propertyId: '7b2f2f2f-8a9b-4f25-ae6d-1d2a1f0c1c33',
+      guests: 4,
+      dateInit: '2026-06-01',
+      dateFinish: '2026-06-03',
+    }).subscribe((response) => {
+      expect(response.name).toBe('Hotel Aurora');
+      expect(response.price).toBe(420000);
+    });
+
+    const req = httpMock.expectOne((request) => {
+      return request.url === 'https://api.example.com/pricing-orchestator/api/Property'
+        && request.params.get('propertyId') === '7b2f2f2f-8a9b-4f25-ae6d-1d2a1f0c1c33'
+        && request.params.get('guests') === '4'
+        && request.params.get('dateInit') === '2026-06-01'
+        && request.params.get('dateFinish') === '2026-06-03';
+    });
+
+    expect(req.request.method).toBe('GET');
+    req.flush({
+      id: '7b2f2f2f-8a9b-4f25-ae6d-1d2a1f0c1c33',
+      name: 'Hotel Aurora',
+      maxCapacity: 4,
+      description: 'Modern hotel near the historic center.',
+      urlBucketPhotos: 'https://picsum.photos/seed/aurora-hero/1200/800',
+      checkInTime: '15:00:00',
+      checkOutTime: '11:00:00',
+      adminGroupId: 'hotel-admins',
+      price: 420000,
+    });
+  });
+
+  it('gets pricing property with fallback to orchestrator', () => {
+    service.getPropertyPricing({
+      propertyId: '7b2f2f2f-8a9b-4f25-ae6d-1d2a1f0c1c33',
+      guests: 2,
+      dateInit: '2026-05-10',
+      dateFinish: '2026-05-12',
+    }).subscribe((response) => {
+      expect(response.price).toBe(560000);
+    });
+
+    const engineReq = httpMock.expectOne((request) => {
+      return request.url === 'https://api.example.com/pricing-engine/api/PropertyPrice'
+        && request.params.get('propertyId') === '7b2f2f2f-8a9b-4f25-ae6d-1d2a1f0c1c33'
+        && request.params.get('guests') === '2'
+        && request.params.get('dateInit') === '2026-05-10'
+        && request.params.get('dateFinish') === '2026-05-12';
+    });
+    expect(engineReq.request.method).toBe('GET');
+    engineReq.flush('engine unavailable', {
+      status: 500,
+      statusText: 'Server Error',
+    });
+
+    const orchestratorReq = httpMock.expectOne((request) => {
+      return request.url === 'https://api.example.com/pricing-orchestator/api/Property'
+        && request.params.get('propertyId') === '7b2f2f2f-8a9b-4f25-ae6d-1d2a1f0c1c33'
+        && request.params.get('guests') === '2'
+        && request.params.get('dateInit') === '2026-05-10'
+        && request.params.get('dateFinish') === '2026-05-12';
+    });
+    expect(orchestratorReq.request.method).toBe('GET');
+    orchestratorReq.flush({
+      id: '7b2f2f2f-8a9b-4f25-ae6d-1d2a1f0c1c33',
+      name: 'Fallback Hotel',
+      price: 560000,
+    });
+  });
+
+  it('gets legacy pricing data from the configured property path', () => {
+    service.getPricingData({
+      roomType: 'suite',
+      currency: 'USD',
+      season: 'high',
+    }).subscribe((response) => {
+      expect(response.roomTypes).toEqual([]);
+      expect(response.seasonalRules).toEqual([]);
+    });
+
+    const req = httpMock.expectOne((request) => {
+      return request.url === 'https://api.example.com/poc-properties/api/property'
+        && request.params.get('roomType') === 'suite'
+        && request.params.get('currency') === 'USD'
+        && request.params.get('season') === 'high'
+        && request.headers.get('Authorization') === 'Bearer property-token';
+    });
+
+    expect(req.request.method).toBe('GET');
+    req.flush({ roomTypes: [], seasonalRules: [] });
+  });
+});

--- a/user_interface/src/app/core/services/pricing-engine.service.ts
+++ b/user_interface/src/app/core/services/pricing-engine.service.ts
@@ -1,0 +1,168 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams, HttpHeaders } from '@angular/common/http';
+import { Observable, firstValueFrom, map, catchError } from 'rxjs';
+import { ConfigService } from './config.service';
+import { PricingData, PricingFilters, RoomType, SeasonalRule } from '../models/pricing.model';
+import { HealthResponse, PropertyPriceQuery, PricingPropertyResponse } from '../models/platform-api.model';
+
+export interface PricingApiResponse {
+  roomTypes: RoomType[];
+  seasonalRules: SeasonalRule[];
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PricingEngineService {
+  private readonly baseUrl = this.config.apiBaseUrl?.replace(/\/$/, '');
+  private readonly propertyPath = this.config.propertyApiPath?.replace(/^\//, '') || 'poc-properties/api/property';
+
+  constructor(private http: HttpClient, private config: ConfigService) {}
+
+  getPricingData(filters: PricingFilters = {}): Observable<PricingData> {
+    const url = this.baseUrl ? `${this.baseUrl}/${this.propertyPath}` : `${this.propertyPath}`;
+
+    let params = new HttpParams();
+
+    if (filters.roomType) {
+      params = params.set('roomType', filters.roomType);
+    }
+
+    if (filters.currency) {
+      params = params.set('currency', filters.currency);
+    }
+
+    if (filters.season) {
+      params = params.set('season', filters.season);
+    }
+
+    const headersConfig: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+
+    if (this.config.propertyApiToken) {
+      headersConfig['Authorization'] = `Bearer ${this.config.propertyApiToken}`;
+    }
+
+    const headers = new HttpHeaders(headersConfig);
+
+    return this.http.get<PricingApiResponse>(url, { params, headers }).pipe(
+      map((response): PricingData => ({
+        roomTypes: response.roomTypes,
+        seasonalRules: response.seasonalRules,
+        isLoading: false,
+      })),
+    );
+  }
+
+  getRoomTypes(filters: PricingFilters = {}): Observable<RoomType[]> {
+    return this.getPricingData(filters).pipe(
+      map((data: PricingData) => data.roomTypes),
+    );
+  }
+
+  getSeasonalRules(filters: PricingFilters = {}): Observable<SeasonalRule[]> {
+    return this.getPricingData(filters).pipe(
+      map((data: PricingData) => data.seasonalRules),
+    );
+  }
+
+  getPricingDataAsync(filters: PricingFilters = {}): Promise<PricingData> {
+    return firstValueFrom(this.getPricingData(filters));
+  }
+
+  getPricingEngineHealth(): Observable<HealthResponse> {
+    return this.http.get<HealthResponse>(this.buildUrl('pricing-engine/api/Health'), {
+      headers: this.defaultHeaders,
+    });
+  }
+
+  getPricingEnginePropertyPrice(params: PropertyPriceQuery): Observable<PricingPropertyResponse> {
+    return this.http.get<PricingPropertyResponse>(this.buildUrl('pricing-engine/api/PropertyPrice'), {
+      headers: this.defaultHeaders,
+      params: this.buildPropertyPriceParams(params),
+    });
+  }
+
+  getPricingOrchestratorHealth(): Observable<HealthResponse> {
+    return this.http.get<HealthResponse>(this.buildUrl('pricing-orchestator/api/Health'), {
+      headers: this.defaultHeaders,
+    });
+  }
+
+  getPricingOrchestratorProperty(params: PropertyPriceQuery): Observable<PricingPropertyResponse> {
+    return this.http.get<PricingPropertyResponse>(this.buildUrl('pricing-orchestator/api/Property'), {
+      headers: this.defaultHeaders,
+      params: this.buildPropertyPriceParams(params),
+    });
+  }
+
+  getPropertyPricing(params: PropertyPriceQuery): Observable<PricingPropertyResponse> {
+    // Try pricing-engine first, fall back to orchestrator if pricing-engine fails.
+    return this.getPricingEnginePropertyPrice(params).pipe(
+      catchError(() => this.getPricingOrchestratorProperty(params)),
+    );
+  }
+
+  private get defaultHeaders(): HttpHeaders {
+    return new HttpHeaders({
+      'Content-Type': 'application/json',
+    });
+  }
+
+  private buildUrl(path: string): string {
+    const normalizedPath = path.replace(/^\//, '');
+    return this.baseUrl ? `${this.baseUrl}/${normalizedPath}` : `/${normalizedPath}`;
+  }
+
+  private buildPropertyPriceParams(params: PropertyPriceQuery): HttpParams {
+    let queryParams = new HttpParams()
+      .set('propertyId', params.propertyId)
+      .set('guests', String(params.guests))
+      .set('dateInit', params.dateInit)
+      .set('dateFinish', params.dateFinish);
+
+    if (params.discountCode) {
+      queryParams = queryParams.set('discountCode', params.discountCode);
+    }
+
+    return queryParams;
+  }
+
+  private normalizeCurrency(currency: string): string {
+    return currency?.trim() || '$';
+  }
+
+  private formatRate(rate: number, currency: string): string {
+    const formatted = new Intl.NumberFormat('en-US', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(rate);
+    return `${currency}${formatted}`;
+  }
+
+  private formatDiscount(discount: number): string {
+    if (!discount) {
+      return 'No discount';
+    }
+    const sign = discount > 0 ? '+' : '';
+    const percentage = Math.abs(discount).toFixed(2);
+    return `${sign}${percentage}% OFF`;
+  }
+
+  private formatDateRange(dateRange: string): string {
+    if (!dateRange) {
+      return '-';
+    }
+    try {
+      const start = new Date(dateRange.split(' - ')[0]);
+      const end = new Date(dateRange.split(' - ')[1]);
+      const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+      const startMonth = months[start.getMonth()];
+      const endMonth = months[end.getMonth()];
+      return `${startMonth} ${start.getDate()} - ${endMonth} ${end.getDate()}`;
+    } catch {
+      return dateRange || '-';
+    }
+  }
+}

--- a/user_interface/src/app/shared/components/portal-hoteles/generic-card/generic-card.component.scss
+++ b/user_interface/src/app/shared/components/portal-hoteles/generic-card/generic-card.component.scss
@@ -4,7 +4,7 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  background: var(--th-color-neutral-0);
+  background: var(--th-white);
   border: 1px dashed var(--th-color-primary-100);
   border-radius: 14px;
   padding: var(--th-space-4);

--- a/user_interface/src/app/shared/components/portal-hoteles/grid-card/grid-card.component.html
+++ b/user_interface/src/app/shared/components/portal-hoteles/grid-card/grid-card.component.html
@@ -1,8 +1,11 @@
 <article class="portal-hoteles-grid-card" [ngClass]="cardClass">
-  <header *ngIf="title || subtitle" class="portal-hoteles-grid-card__header">
-    <div>
+  <header class="portal-hoteles-grid-card__header">
+    <div class="portal-hoteles-grid-card__header-copy">
       <h2 *ngIf="title">{{ title }}</h2>
       <p *ngIf="subtitle">{{ subtitle }}</p>
+    </div>
+    <div class="portal-hoteles-grid-card__header-actions">
+      <ng-content select="[slot='header-actions']"></ng-content>
     </div>
   </header>
 

--- a/user_interface/src/app/shared/components/portal-hoteles/grid-card/grid-card.component.scss
+++ b/user_interface/src/app/shared/components/portal-hoteles/grid-card/grid-card.component.scss
@@ -1,22 +1,43 @@
 .portal-hoteles-grid-card {
-  background: var(--th-color-neutral-0);
+  background: var(--th-white);
   border: 1px solid var(--th-color-primary-100);
   border-radius: 16px;
   box-shadow: 0 12px 24px rgba(20, 53, 88, 0.08);
 }
 
 .portal-hoteles-grid-card__header {
+  display: none;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--th-space-4);
   margin-bottom: var(--th-space-4);
+}
+
+.portal-hoteles-grid-card__header:has(.portal-hoteles-grid-card__header-copy:not(:empty)),
+.portal-hoteles-grid-card__header:has(.portal-hoteles-grid-card__header-actions:not(:empty)) {
+  display: flex;
+}
+
+.portal-hoteles-grid-card__header-copy {
+  min-width: 0;
 }
 
 .portal-hoteles-grid-card__header h2 {
   margin: 0;
-  font-size: var(--th-font-size-2xl);
+  font-size: var(--th-text-h2-size);
+  font-weight: var(--th-font-weight-bold);
 }
 
 .portal-hoteles-grid-card__header p {
   margin: var(--th-space-1) 0 0;
   color: var(--th-color-neutral-700);
+}
+
+.portal-hoteles-grid-card__header-actions {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-shrink: 0;
 }
 
 .portal-hoteles-grid-card__body {

--- a/user_interface/src/app/shared/components/portal-hoteles/grid-card/grid-card.component.spec.ts
+++ b/user_interface/src/app/shared/components/portal-hoteles/grid-card/grid-card.component.spec.ts
@@ -1,6 +1,19 @@
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PortalHotelesGridCardComponent } from './grid-card.component';
+
+@Component({
+  standalone: true,
+  imports: [PortalHotelesGridCardComponent],
+  template: `
+    <portal-hoteles-grid-card title="Reservations" subtitle="Manage all bookings">
+      <div slot="header-actions" class="test-header-actions">PDF Excel</div>
+      <p class="test-body">Body content</p>
+    </portal-hoteles-grid-card>
+  `,
+})
+class GridCardHostComponent {}
 
 describe('PortalHotelesGridCardComponent', () => {
   let component: PortalHotelesGridCardComponent;
@@ -28,5 +41,23 @@ describe('PortalHotelesGridCardComponent', () => {
     // Assert
     expect(element.textContent).toContain('Reservations');
     expect(element.textContent).toContain('Manage all bookings');
+  });
+
+  it('projects header actions into the card header', async () => {
+    // Arrange
+    await TestBed.resetTestingModule().configureTestingModule({
+      imports: [GridCardHostComponent],
+    }).compileComponents();
+
+    const hostFixture = TestBed.createComponent(GridCardHostComponent);
+
+    // Act
+    hostFixture.detectChanges();
+    const element = hostFixture.nativeElement as HTMLElement;
+    const headerActions = element.querySelector('.portal-hoteles-grid-card__header-actions');
+
+    // Assert
+    expect(headerActions?.textContent).toContain('PDF Excel');
+    expect(element.textContent).toContain('Body content');
   });
 });

--- a/user_interface/src/app/shared/components/portal-hoteles/revenue-chart-card/revenue-chart-card.component.html
+++ b/user_interface/src/app/shared/components/portal-hoteles/revenue-chart-card/revenue-chart-card.component.html
@@ -1,0 +1,39 @@
+<portal-hoteles-grid-card
+  cardClass="portal-hoteles-grid-card--panel portal-hoteles-grid-card--wide"
+  [title]="title"
+  [subtitle]="subtitle"
+>
+  <div class="portal-hoteles-revenue-chart-card__toolbar">
+    <ion-chip color="light">{{ periodLabel }}</ion-chip>
+    <ion-select
+      interface="popover"
+      [value]="selectedPeriod"
+      aria-label="Select chart period"
+      (ionChange)="onPeriodSelectionChange($event)"
+    >
+      <ion-select-option *ngFor="let option of periodOptions" [value]="option">{{ option }}</ion-select-option>
+    </ion-select>
+  </div>
+
+  <div class="portal-hoteles-revenue-chart-card__chart" [attr.aria-label]="ariaDescription" role="img" *ngIf="hasData; else emptyChart">
+    <ol class="portal-hoteles-revenue-chart-card__y-axis" aria-hidden="true">
+      <li *ngFor="let tick of resolvedTicks">{{ formatCurrency(tick) }}</li>
+    </ol>
+
+    <ul class="portal-hoteles-revenue-chart-card__bars">
+      <li class="portal-hoteles-revenue-chart-card__bar-item" *ngFor="let point of chartPoints; trackBy: trackByCategory">
+        <div
+          class="portal-hoteles-revenue-chart-card__bar"
+          [style.height.%]="getBarHeight(point.value)"
+          [attr.aria-label]="getBarAriaLabel(point)"
+          tabindex="0"
+        ></div>
+        <span class="portal-hoteles-revenue-chart-card__bar-label">{{ point.category }}</span>
+      </li>
+    </ul>
+  </div>
+
+  <ng-template #emptyChart>
+    <p class="portal-hoteles-revenue-chart-card__empty" aria-live="polite" aria-atomic="true">No revenue data available.</p>
+  </ng-template>
+</portal-hoteles-grid-card>

--- a/user_interface/src/app/shared/components/portal-hoteles/revenue-chart-card/revenue-chart-card.component.scss
+++ b/user_interface/src/app/shared/components/portal-hoteles/revenue-chart-card/revenue-chart-card.component.scss
@@ -1,0 +1,94 @@
+.portal-hoteles-revenue-chart-card__toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--th-space-2);
+  margin-bottom: var(--th-space-4);
+}
+
+.portal-hoteles-revenue-chart-card__chart {
+  display: grid;
+  grid-template-columns: minmax(72px, auto) minmax(0, 1fr);
+  gap: var(--th-space-4);
+  align-items: end;
+  min-height: 260px;
+}
+
+.portal-hoteles-revenue-chart-card__y-axis {
+  display: grid;
+  align-self: stretch;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  color: var(--th-neutral-600);
+  font-size: var(--th-text-caption-size);
+}
+
+.portal-hoteles-revenue-chart-card__y-axis li {
+  display: flex;
+  align-items: center;
+  border-top: 1px dashed var(--th-neutral-300);
+  padding-top: var(--th-space-1);
+}
+
+.portal-hoteles-revenue-chart-card__bars {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: var(--th-space-3);
+  grid-template-columns: repeat(auto-fit, minmax(72px, 1fr));
+  align-items: end;
+  min-height: 260px;
+}
+
+.portal-hoteles-revenue-chart-card__bar-item {
+  display: grid;
+  justify-items: center;
+  gap: var(--th-space-2);
+}
+
+.portal-hoteles-revenue-chart-card__bar {
+  width: 100%;
+  max-width: 52px;
+  min-height: 6px;
+  border-radius: var(--th-radius-md);
+  background: linear-gradient(180deg, var(--th-primary-500) 0%, var(--th-primary-700) 100%);
+  border: 1px solid var(--th-primary-700);
+}
+
+.portal-hoteles-revenue-chart-card__bar:focus-visible {
+  outline: 2px solid var(--th-primary-700);
+  outline-offset: 2px;
+}
+
+.portal-hoteles-revenue-chart-card__bar-label {
+  color: var(--th-neutral-700);
+  font-size: var(--th-text-caption-size);
+  text-align: center;
+}
+
+.portal-hoteles-revenue-chart-card__empty {
+  margin: var(--th-space-2) 0 0;
+  color: var(--th-neutral-700);
+}
+
+@media (max-width: 960px) {
+  .portal-hoteles-revenue-chart-card__chart {
+    grid-template-columns: 1fr;
+  }
+
+  .portal-hoteles-revenue-chart-card__y-axis {
+    grid-auto-flow: column;
+    overflow-x: auto;
+    gap: var(--th-space-3);
+    border-bottom: 1px dashed var(--th-neutral-300);
+    padding-bottom: var(--th-space-2);
+  }
+
+  .portal-hoteles-revenue-chart-card__y-axis li {
+    border-top: 0;
+    padding-top: 0;
+    white-space: nowrap;
+  }
+}

--- a/user_interface/src/app/shared/components/portal-hoteles/revenue-chart-card/revenue-chart-card.component.spec.ts
+++ b/user_interface/src/app/shared/components/portal-hoteles/revenue-chart-card/revenue-chart-card.component.spec.ts
@@ -1,0 +1,98 @@
+/// <reference types="jasmine" />
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PortalHotelesRevenueChartCardComponent } from './revenue-chart-card.component';
+
+describe('PortalHotelesRevenueChartCardComponent', () => {
+  let component: PortalHotelesRevenueChartCardComponent;
+  let fixture: ComponentFixture<PortalHotelesRevenueChartCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PortalHotelesRevenueChartCardComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PortalHotelesRevenueChartCardComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('creates with minimal defaults', () => {
+    // Arrange
+
+    // Act
+    fixture.detectChanges();
+
+    // Assert
+    expect(component).toBeTruthy();
+    expect(component.hasData).toBeFalse();
+  });
+
+  it('renders bars using the shortest categories and values length', () => {
+    // Arrange
+    component.categories = ['Jan', 'Feb', 'Mar'];
+    component.values = [1200, 900];
+
+    // Act
+    fixture.detectChanges();
+
+    // Assert
+    const element = fixture.nativeElement as HTMLElement;
+    const bars = element.querySelectorAll('.portal-hoteles-revenue-chart-card__bar-item');
+    expect(bars.length).toBe(2);
+    expect(component.chartPoints[0].category).toBe('Jan');
+    expect(component.chartPoints[1].category).toBe('Feb');
+  });
+
+  it('shows empty fallback when chart input is empty', () => {
+    // Arrange
+    component.categories = [];
+    component.values = [];
+
+    // Act
+    fixture.detectChanges();
+
+    // Assert
+    const element = fixture.nativeElement as HTMLElement;
+    expect(element.textContent).toContain('No revenue data available.');
+  });
+
+  it('computes max scale when maxValue is not provided', () => {
+    // Arrange
+    component.categories = ['Jan', 'Feb'];
+    component.values = [1000, 2000];
+
+    // Act
+    fixture.detectChanges();
+
+    // Assert
+    expect(component.resolvedMaxValue).toBe(2000);
+    expect(component.getBarHeight(1000)).toBe(50);
+  });
+
+  it('applies aria description to chart container', () => {
+    // Arrange
+    component.categories = ['Jan'];
+    component.values = [1000];
+    component.ariaDescription = 'Custom chart summary';
+
+    // Act
+    fixture.detectChanges();
+
+    // Assert
+    const element = fixture.nativeElement as HTMLElement;
+    const chart = element.querySelector('.portal-hoteles-revenue-chart-card__chart');
+    expect(chart?.getAttribute('aria-label')).toBe('Custom chart summary');
+  });
+
+  it('emits periodChange when selection changes', () => {
+    // Arrange
+    spyOn(component.periodChange, 'emit');
+
+    // Act
+    component.onPeriodSelectionChange({ detail: { value: 'Last 12 months' } } as CustomEvent);
+
+    // Assert
+    expect(component.periodChange.emit).toHaveBeenCalledWith('Last 12 months');
+  });
+});

--- a/user_interface/src/app/shared/components/portal-hoteles/revenue-chart-card/revenue-chart-card.component.ts
+++ b/user_interface/src/app/shared/components/portal-hoteles/revenue-chart-card/revenue-chart-card.component.ts
@@ -1,0 +1,103 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { IonicModule } from '@ionic/angular';
+import { PortalHotelesGridCardComponent } from '@travelhub/shared/components/portal-hoteles/grid-card/grid-card.component';
+
+interface RevenueChartPoint {
+  category: string;
+  value: number;
+}
+
+@Component({
+  selector: 'portal-hoteles-revenue-chart-card',
+  templateUrl: './revenue-chart-card.component.html',
+  styleUrls: ['./revenue-chart-card.component.scss'],
+  standalone: true,
+  imports: [CommonModule, IonicModule, PortalHotelesGridCardComponent],
+})
+export class PortalHotelesRevenueChartCardComponent {
+  @Input() title = 'Revenue Overview';
+  @Input() subtitle = 'Track monthly revenue trends';
+  @Input() periodLabel = 'Last 6 months';
+  @Input() periodOptions: string[] = ['Last 6 months'];
+  @Input() categories: string[] = [];
+  @Input() values: number[] = [];
+  @Input() currencyPrefix = '$';
+  @Input() yAxisTicks: number[] = [];
+  @Input() ariaDescription = 'Revenue bar chart';
+  @Input() maxValue?: number;
+
+  @Output() periodChange = new EventEmitter<string>();
+
+  get hasData(): boolean {
+    return this.chartPoints.length > 0;
+  }
+
+  get chartPoints(): RevenueChartPoint[] {
+    const size = Math.min(this.categories.length, this.values.length);
+    if (!size) {
+      return [];
+    }
+
+    return Array.from({ length: size }, (_, index) => ({
+      category: this.categories[index],
+      value: Math.max(0, this.values[index] ?? 0),
+    }));
+  }
+
+  get resolvedMaxValue(): number {
+    if (typeof this.maxValue === 'number' && this.maxValue > 0) {
+      return this.maxValue;
+    }
+
+    const computedMax = Math.max(...this.chartPoints.map((point) => point.value), 0);
+    return computedMax > 0 ? computedMax : 1;
+  }
+
+  get resolvedTicks(): number[] {
+    const explicitTicks = this.yAxisTicks.filter((tick) => Number.isFinite(tick) && tick >= 0);
+    if (explicitTicks.length) {
+      return [...explicitTicks].sort((a, b) => b - a);
+    }
+
+    const max = this.resolvedMaxValue;
+    return [max, Math.round(max * 0.75), Math.round(max * 0.5), Math.round(max * 0.25), 0];
+  }
+
+  get selectedPeriod(): string {
+    if (this.periodOptions.includes(this.periodLabel)) {
+      return this.periodLabel;
+    }
+
+    return this.periodOptions[0] || this.periodLabel;
+  }
+
+  onPeriodSelectionChange(event: CustomEvent): void {
+    const nextValue = String(event.detail.value || '').trim();
+    if (!nextValue) {
+      return;
+    }
+
+    this.periodChange.emit(nextValue);
+  }
+
+  getBarHeight(value: number): number {
+    return (value / this.resolvedMaxValue) * 100;
+  }
+
+  formatCurrency(value: number): string {
+    const formatted = new Intl.NumberFormat('en-US', {
+      maximumFractionDigits: 0,
+    }).format(value);
+
+    return `${this.currencyPrefix}${formatted}`;
+  }
+
+  getBarAriaLabel(point: RevenueChartPoint): string {
+    return `${point.category}: ${this.formatCurrency(point.value)}`;
+  }
+
+  trackByCategory(_index: number, point: RevenueChartPoint): string {
+    return point.category;
+  }
+}

--- a/user_interface/src/assets/config.json
+++ b/user_interface/src/assets/config.json
@@ -1,6 +1,6 @@
 {
   "playwrightBaseUrl": "http://localhost:4200",
-  "apiBaseUrl": "https://n548xflwbl.execute-api.us-east-1.amazonaws.com/",
+  "apiBaseUrl": "http://localhost:8081",
   "propertyApiPath": "/poc-properties/api/property",
   "propertyApiToken": "",
   "bookingApiPath": "/booking-orchestrator/api/reservations",


### PR DESCRIPTION
This pull request introduces a new "Pricing Configuration" feature to the Portal Hoteles frontend, including its UI, routing, and unit tests. It also strengthens frontend guardrails by requiring accessibility (a11y) compliance and enhances the reliability of pricing-related backend mocks. Additionally, it adjusts the Wiremock service port for local testing.

**Key changes:**

### New Pricing Configuration Feature
* Added a new route `/pricing` to `app-routing.module.ts`, loading a dedicated `pricing-configuration` page for pricing management in Portal Hoteles.
* Implemented the `pricing-configuration.page.html` UI, featuring room rate and seasonal pricing management tables, filters, and action buttons, with accessibility attributes and empty/loading states.
* Added comprehensive unit tests for the `pricing-configuration` page, covering data loading, formatting, error handling, and session integration.

### Frontend Guardrails & Accessibility
* Updated `.github/instructions/frontend-guardrails.instructions.md` to mandate accessibility compliance (semantic structure, keyboard access, visible focus, labels, contrast) for all UI changes, with required use of `a11y-audit` and explicit reporting of any issues. Also updated checklists and response templates to include a11y considerations. [[1]](diffhunk://#diff-9ab9b249377fae32c2d2bc8dcca7c70a8fd26553e4cf2403760c68979898866bL2-R2) [[2]](diffhunk://#diff-9ab9b249377fae32c2d2bc8dcca7c70a8fd26553e4cf2403760c68979898866bR57-R61) [[3]](diffhunk://#diff-9ab9b249377fae32c2d2bc8dcca7c70a8fd26553e4cf2403760c68979898866bR77) [[4]](diffhunk://#diff-9ab9b249377fae32c2d2bc8dcca7c70a8fd26553e4cf2403760c68979898866bR99-R102)

### E2E and Local Testing Improvements
* Enhanced Wiremock mock definitions for pricing-related endpoints (`pricingengine-propertyprice.json`, `pricingorchestator-property.json`) to require specific query parameters, improving test reliability and input validation. [[1]](diffhunk://#diff-ae29a7ce6ff619bd1dc8e484644020ea286307e65c475d07e75fac3df66ad4a1L4-R18) [[2]](diffhunk://#diff-0447f3bfa6fa81d556ad2136e918c9a9f513a36f19eddf0f44b1a4d5be5b2c12L4-R18)
* Changed the Wiremock service port mapping in `podman-compose.yml` from `8080` to `8081` to avoid conflicts and improve local development experience.